### PR TITLE
fix: set max dropdown items when searching

### DIFF
--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -269,6 +269,7 @@ const Dropdown = ({
   placeholder,
   emptyMessage,
   isChanged,
+  maxOptionsShown = 25,
 }) => {
   value = useMemo(() => compact(value), [value])
 
@@ -344,7 +345,9 @@ const Dropdown = ({
   if (search && searchForm) {
     // filter out search matches
     options = options.filter((o) =>
-      searchFields.some((key) => o[key]?.toLowerCase()?.includes(searchForm.toLowerCase())),
+      searchFields.some(
+        (key) => o[key] && String(o[key])?.toLowerCase()?.includes(searchForm.toLowerCase()),
+      ),
     )
   }
 
@@ -512,6 +515,12 @@ const Dropdown = ({
     return null
   }, [valueIcon, multiSelect, options])
 
+  // splice to maxOptionsShown or 25 items
+  const showOptions = useMemo(
+    () => (search ? [...options].splice(0, maxOptionsShown) : options),
+    [options, maxOptionsShown],
+  )
+
   return (
     <DropdownStyled
       onKeyDown={handleKeyPress}
@@ -555,7 +564,7 @@ const Dropdown = ({
             </SearchStyled>
           )}
           <OptionsStyled isOpen={isOpen} message={message} ref={optionsRef} style={{ minWidth }}>
-            {options.map((option, i) => (
+            {showOptions.map((option, i) => (
               <ListItemStyled
                 key={option[dataKey]}
                 onClick={(e) => handleChange(e, option[dataKey])}
@@ -606,6 +615,9 @@ Dropdown.propTypes = {
   placeholder: PropTypes.string,
   isChanged: PropTypes.bool,
   isMultiple: PropTypes.bool,
+  onChange: PropTypes.func,
+  minWidth: PropTypes.string,
+  maxOptionsShown: PropTypes.number,
 }
 
 export default Dropdown

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -12,14 +12,12 @@ import {
   Section,
 } from '/src/components'
 
-const dropdownOptions = [
-  { label: 'Option 1', value: 1, icon: 'visibility' },
-  { label: 'Option 2', value: 2, icon: 'visibility' },
-  { label: 'Option 3', value: 3, icon: 'visibility' },
-  { label: 'Option 4', value: 4, icon: 'visibility' },
-  { label: 'Option 5', value: 5, icon: 'visibility' },
-  { label: 'Option 6', value: 6, icon: 'visibility' },
-]
+// create 1000 items for the dropdown
+const dropdownOptions = Array.from({ length: 1000 }, (_, i) => ({
+  label: `Option ${i + 1}`,
+  value: i + 1,
+  icon: 'visibility',
+}))
 
 const InputDemo = () => {
   // demo for color picker
@@ -65,6 +63,7 @@ const InputDemo = () => {
               value={dropdownValue}
               onChange={setDropdownValue}
               widthExpand={true}
+              search
             />
           </FormRow>
           <FormRow>{JSON.stringify(dropdownValue)}</FormRow>


### PR DESCRIPTION
When the search prop is enabled on a dropdown, a new maxOptionsShown prop with a default value of 25 will be activated. 

This feature limits the number of rendered items to improve performance. 

Items that exceed this maximum will not be rendered in the DOM, but can still be searched for and selected.