### PR TITLE
fix: onClearNoValue prop to show clear button even with no value

### DIFF
--- a/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
@@ -50,7 +50,10 @@ const ContentStyled = styled.div`
 `
 
 export interface DefaultValueTemplateProps
-  extends Pick<DropdownProps, 'value' | 'isMultiple' | 'dropIcon' | 'onClear' | 'placeholder'> {
+  extends Pick<
+    DropdownProps,
+    'value' | 'isMultiple' | 'dropIcon' | 'onClear' | 'onClearNoValue' | 'placeholder'
+  > {
   displayIcon?: string
   style?: React.CSSProperties
   children?: React.ReactNode
@@ -66,6 +69,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
   dropIcon = 'expand_more',
   displayIcon,
   onClear,
+  onClearNoValue,
   children,
   style,
   valueStyle,
@@ -80,10 +84,11 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
     <DefaultValueStyled style={style} isOpen={!!isOpen} className={className}>
       {noValue ? (
         <>
-          {!value.length && (
-            <ContentStyled>
-              <ValueStyled>{placeholder}</ValueStyled>
-            </ContentStyled>
+          <ContentStyled>
+            <ValueStyled>{placeholder}</ValueStyled>
+          </ContentStyled>
+          {onClear && onClearNoValue && (
+            <Icon icon={'close'} onClick={onClear} id="clear" className="control" tabIndex={0} />
           )}
         </>
       ) : (

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -383,6 +383,7 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   maxSelected?: number
   dropIcon?: IconType
   onClear?: () => void
+  onClearNoValue?: boolean
   editable?: boolean
   maxHeight?: number
   disableReorder?: boolean
@@ -430,6 +431,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
       maxSelected,
       dropIcon = 'expand_more',
       onClear,
+      onClearNoValue,
       editable,
       maxHeight = 300,
       disableReorder,
@@ -862,6 +864,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
       dropIcon,
       displayIcon,
       onClear: onClear ? handleClear : undefined,
+      onClearNoValue,
       style: valueStyle,
       placeholder,
       isOpen,
@@ -874,7 +877,17 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
       if (typeof valueTemplate === 'function') return valueTemplate
       if (valueTemplate === 'tags')
         return () => <TagsValueTemplate {...DefaultValueTemplateProps} />
-    }, [valueTemplate, value, isOpen, onClear, selected, handleClear, isMultiple, dropIcon])
+    }, [
+      valueTemplate,
+      value,
+      isOpen,
+      onClear,
+      onClearNoValue,
+      selected,
+      handleClear,
+      isMultiple,
+      dropIcon,
+    ])
 
     return (
       <DropdownStyled


### PR DESCRIPTION
Use case: set a field with list of strings to `null` instead of `[]` to set inheritance from parent. 

![image](https://github.com/ynput/ayon-react-components/assets/49156310/67f6f28a-54eb-41d2-936a-f4292896943b)
