### PR TITLE
Fixes: entity card, switch, assignee select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -11,7 +11,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   tooltip?: string
   link?: boolean
   disabled?: boolean
-  iconProps?: IconProps
+  iconProps?: Omit<IconProps, 'icon'>
   variant?: 'surface' | 'tonal' | 'filled' | 'nav' | 'text' | 'tertiary'
   className?: string
   selected?: boolean

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes, forwardRef } from 'react'
 import * as Styled from './Button.styled'
-import { Icon, IconType } from '../Icon'
+import { Icon, IconProps, IconType } from '../Icon'
 import clsx from 'clsx'
 import Typography from '../theme/typography.module.css'
 
@@ -11,7 +11,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   tooltip?: string
   link?: boolean
   disabled?: boolean
-  iconStyle?: React.CSSProperties
+  iconProps?: IconProps
   variant?: 'surface' | 'tonal' | 'filled' | 'nav' | 'text' | 'tertiary'
   className?: string
   selected?: boolean
@@ -19,7 +19,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { label, icon, tooltip, link, iconStyle, variant = 'surface', className, selected, ...props },
+    { label, icon, tooltip, link, variant = 'surface', className, selected, iconProps, ...props },
     ref,
   ) => {
     return (
@@ -33,7 +33,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
         ref={ref}
       >
-        {!link && icon && <Icon icon={icon} />} {label} {props.children}
+        {!link && icon && <Icon icon={icon} {...iconProps} />} {label} {props.children}
       </Styled.Button>
     )
   },

--- a/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components'
 import { UserImagesStacked } from '../../User/UserImagesStacked'
 import { forwardRef } from 'react'
-import { Icon } from '../../Icon'
+import { Icon, IconType } from '../../Icon'
 
 const FieldStyled = styled.div<{ disabled?: boolean; isMultiple?: boolean }>`
   position: relative;
@@ -54,7 +54,7 @@ export interface AssigneeFieldProps extends React.HTMLAttributes<HTMLDivElement>
   isMultiple?: boolean
   placeholder?: string
   emptyMessage?: string
-  emptyIcon?: boolean
+  emptyIcon?: IconType | null
   size?: number
 }
 
@@ -66,7 +66,7 @@ export const AssigneeField = forwardRef<HTMLDivElement, AssigneeFieldProps>(
       disabled,
       isMultiple,
       placeholder,
-      emptyIcon = true,
+      emptyIcon = 'add_circle',
       emptyMessage = '',
       size = 21,
       ...props
@@ -99,7 +99,7 @@ export const AssigneeField = forwardRef<HTMLDivElement, AssigneeFieldProps>(
             </>
           ) : (
             <>
-              {emptyIcon && !isMultiple && <Icon icon="add_circle" />}
+              {emptyIcon && !isMultiple && <Icon icon={emptyIcon} />}
               {emptyMessage && <span>{emptyMessage}</span>}
             </>
           )

--- a/src/Dropdowns/AssigneeSelect/AssigneeSelect.stories.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeSelect.stories.tsx
@@ -26,9 +26,7 @@ const users = Array.from({ length: 3 }, (_, i) => ({
 }))
 
 const Template = (args: AssigneeSelectProps) => {
-  const initValue = users.map((user) => user.name)
-
-  const [value, setValue] = useState(initValue)
+  const [value, setValue] = useState(args.value)
 
   return (
     <AssigneeSelect
@@ -43,4 +41,15 @@ const Template = (args: AssigneeSelectProps) => {
 
 export const Default: Story = {
   render: Template,
+  args: {
+    value: users.map((user) => user.name),
+  },
+}
+export const Custom: Story = {
+  render: Template,
+  args: {
+    emptyMessage: 'Assignees',
+    emptyIcon: 'group',
+    value: [],
+  },
 }

--- a/src/Dropdowns/Dropdown/Dropdown.styled.ts
+++ b/src/Dropdowns/Dropdown/Dropdown.styled.ts
@@ -270,7 +270,7 @@ export const DefaultItem = styled.span<{
   display: flex;
   gap: 8px;
   align-items: center;
-  height: 30px;
+  height: 32px;
   padding: 0 8px;
 
   ${({ $isSelected }) =>

--- a/src/EntityCard/EntityCard.stories.tsx
+++ b/src/EntityCard/EntityCard.stories.tsx
@@ -26,6 +26,7 @@ const initData: DataProps = {
   imageUrl: getRandomImage(),
   icon: 'visibility',
   iconColor: '#FF982E',
+  assignees: [{ fullName: 'John Doe', avatarUrl: getRandomImage() }, { fullName: 'John Doe' }],
 }
 
 const Template = (props: EntityCardProps) => {

--- a/src/EntityCard/EntityCard.styled.ts
+++ b/src/EntityCard/EntityCard.styled.ts
@@ -24,7 +24,8 @@ const cardHoverStyles = css`
   .description {
     grid-template-rows: 1fr;
     /* transition-delay: 100ms; */
-    padding-top: 2px;
+    padding: 2px;
+    padding-bottom: 0;
   }
 `
 
@@ -63,7 +64,7 @@ export const Card = styled.div<StyledEntityCardProps>`
   height: auto;
   aspect-ratio: 16 / 9;
 
-  padding: 4px;
+  padding: 2px;
   /* thumbnail variant no padding */
   ${({ $variant }) =>
     $variant === 'thumbnail' &&
@@ -85,7 +86,7 @@ export const Card = styled.div<StyledEntityCardProps>`
   user-select: none;
 
   /* style */
-  border-radius: var(--border-radius-xl);
+  border-radius: var(--border-radius-xxl);
   background-color: var(--md-sys-color-surface-container-high);
 
   &:hover {
@@ -135,7 +136,8 @@ export const Card = styled.div<StyledEntityCardProps>`
       /* description stays open */
       .description {
         grid-template-rows: 1fr;
-        padding-top: 2px;
+        padding: 2px;
+        padding-bottom: 0;
         transition-delay: 0;
       }
 
@@ -290,7 +292,7 @@ export const Thumbnail = styled.div<StyledThumbnailProps>`
   align-self: stretch;
   z-index: 50;
 
-  border-radius: var(--border-radius-l);
+  border-radius: var(--border-radius-xl);
   background-color: var(--md-sys-color-surface-container);
 
   /* image styles */

--- a/src/EntityCard/EntityCard.styled.ts
+++ b/src/EntityCard/EntityCard.styled.ts
@@ -167,6 +167,17 @@ export const Card = styled.div<StyledEntityCardProps>`
     transition: opacity var(--loading-transition);
   }
 
+  .assignees {
+    padding: 1px;
+    border-radius: 14px;
+    min-width: max-content;
+    color: red;
+
+    .user-image {
+      border-color: var(--md-sys-color-surface-container-high);
+    }
+  }
+
   /* set opacity to 0 when not loading */
   ${({ $isLoading }) =>
     $isLoading
@@ -180,7 +191,8 @@ export const Card = styled.div<StyledEntityCardProps>`
             min-width: 50%;
 
             &.status,
-            &.notification {
+            &.notification,
+            &.assignees {
               min-width: 28px;
             }
             /* hide all text and icons */
@@ -229,7 +241,8 @@ export const Card = styled.div<StyledEntityCardProps>`
         }
 
         &.status,
-        &.notification {
+        &.notification,
+        &.assignees {
           min-width: 28px;
         }
       }

--- a/src/EntityCard/EntityCard.tsx
+++ b/src/EntityCard/EntityCard.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useState } from 'react'
 import { Icon, IconType } from '../Icon'
 import * as Styled from './EntityCard.styled'
 import useImageLoading from '../helpers/useImageLoading'
+import { User, UserImagesStacked } from '../User/UserImagesStacked'
 
 type NotificationType = 'comment' | 'due' | 'overdue'
 
@@ -43,6 +44,7 @@ export interface EntityCardProps extends React.HTMLAttributes<HTMLDivElement> {
   isDragging?: boolean
   isDraggable?: boolean
   disabled?: boolean
+  assignees?: User[]
   variant?: 'thumbnail' | 'basic' | 'full'
   onThumbnailKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void
   onActivate?: () => void
@@ -71,6 +73,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
       isDraggable = false,
       onThumbnailKeyDown,
       onActivate,
+      assignees,
       ...props
     },
     ref,
@@ -156,9 +159,15 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
               </Styled.Title>
             )}
             {/* bottom right icon */}
-            {notificationIcon && !hideIcons && (
+            {notificationIcon && !hideIcons && !assignees?.length && (
               <Styled.Title className="notification">
                 <Icon icon={notificationIcon?.icon} style={{ color: notificationIcon?.color }} />
+              </Styled.Title>
+            )}
+            {/* bottom right assignees */}
+            {assignees?.length && (
+              <Styled.Title className="assignees">
+                <UserImagesStacked users={assignees} size={26} gap={-0.5} />
               </Styled.Title>
             )}
           </Styled.Row>

--- a/src/Inputs/InputSwitch/InputSwitch.styled.ts
+++ b/src/Inputs/InputSwitch/InputSwitch.styled.ts
@@ -43,6 +43,7 @@ export const Switch = styled.div`
         bottom: calc(var(--bheight) * 0.1);
         transition: 0.2s;
         border-radius: 50%;
+        scale: 0.8;
       }
     }
 
@@ -64,6 +65,7 @@ export const Switch = styled.div`
       border-color: var(--md-sys-color-primary);
       &::before {
         transform: translateX(calc(var(--bheight) * 0.75));
+        scale: 1;
         background-color: var(--md-sys-color-on-primary);
       }
 
@@ -76,6 +78,17 @@ export const Switch = styled.div`
 
     input:focus-visible + * {
       outline: 2px solid var(--md-sys-color-tertiary) !important;
+    }
+
+    input:disabled + .slider {
+      border-color: transparent;
+      &::before {
+        opacity: 0.4;
+      }
+
+      &:hover {
+        background-color: var(--md-sys-color-surface-container-highest);
+      }
     }
   } // switch-body
 `

--- a/src/User/UserImage/UserImage.styled.ts
+++ b/src/User/UserImage/UserImage.styled.ts
@@ -15,6 +15,7 @@ export const CircleImage = styled.span`
   background-color: var(--md-sys-color-surface-container-highest);
   border: solid 1px var(--md-sys-color-outline);
   user-select: none;
+  color: var(--md-sys-color-on-surface);
 
   img {
     width: 100%;

--- a/src/User/UserImage/UserImage.tsx
+++ b/src/User/UserImage/UserImage.tsx
@@ -9,7 +9,7 @@ export interface UserImageProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 export const UserImage = forwardRef<HTMLSpanElement, UserImageProps>(
-  ({ src, fullName, size = 30, highlight, ...props }, ref) => {
+  ({ src, fullName, size = 30, highlight, className, ...props }, ref) => {
     const fontSize = Math.round((13 / 30) * size)
 
     const initials = fullName
@@ -23,6 +23,8 @@ export const UserImage = forwardRef<HTMLSpanElement, UserImageProps>(
         style={{ width: size, maxHeight: size, minHeight: size, ...props.style }}
         $highlight={highlight}
         ref={ref}
+        className={`${className ? className : ''} ${src ? '' : 'initials'} user-image
+        `}
         {...props}
       >
         {src ? <img src={src} /> : <span style={{ fontSize: `${fontSize}px` }}>{initials}</span>}

--- a/src/User/UserImagesStacked/UserImagesStacked.tsx
+++ b/src/User/UserImagesStacked/UserImagesStacked.tsx
@@ -11,12 +11,14 @@ const StackedStyled = styled.div`
   }
 `
 
+export interface User {
+  avatarUrl?: string
+  fullName?: string
+  self?: boolean
+}
+
 export interface UserImagesStackedProps extends React.HTMLAttributes<HTMLDivElement> {
-  users: {
-    avatarUrl?: string
-    fullName?: string
-    self?: boolean
-  }[]
+  users: User[]
   size?: number
   gap?: number
   max?: number
@@ -41,7 +43,7 @@ export const UserImagesStacked = forwardRef<HTMLDivElement, UserImagesStackedPro
             src={user.avatarUrl}
             key={i}
             fullName={user.fullName || ''}
-            style={{ zIndex: -i, ...userStyle }}
+            style={{ zIndex: -i, width: size, height: size, ...userStyle }}
             highlight={user.self}
             size={size}
           />

--- a/src/helpers/getRandomImage.ts
+++ b/src/helpers/getRandomImage.ts
@@ -7,9 +7,7 @@ const getRandomImage = (seed?: string) => {
   // random width between 200 and 1000
   const width = Math.floor(Math.random() * 800) + 200
   const height = Math.floor(Math.random() * 800) + 200
-  const randomImage = `
-  https://picsum.photos/seed/${seed}/${width}/${height}
-  `
+  const randomImage = `https://picsum.photos/seed/${seed}/${width}/${height}`
 
   return randomImage
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -69,7 +69,8 @@
 
   --border-radius-m: 4px;
   --border-radius-l: 8px;
-  --border-radius-xl: 12px;
+  --border-radius-xl: 10px;
+  --border-radius-xxl: 12px;
 
   --padding-s: 4px;
   --padding-m: 8px;


### PR DESCRIPTION
- Switch disabled styles
- AssigneeSelect `emptyIcon` prop now takes icon or null to remove icon.
- Fixed initials colour issue on UserImage
- Added classnames to UserImage
- Dropdown height 30px to 32px
- EntityCard now supports assignees images in the bottom right corner
- EntityCard border from 4px to 2px
- Button now accepts `iconProps` prop
- Bumped version