### PR TITLE
Fix/file upload returning func not files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/FileUpload/FileUpload.tsx
+++ b/src/FileUpload/FileUpload.tsx
@@ -361,7 +361,13 @@ export const FileUpload = forwardRef<HTMLFormElement, FileUploadProps>(
       }
 
       if (!acceptedFiles.length) return
-      else setFiles((files) => files.concat(acceptedFiles))
+      else {
+        const newFiles = [...files]
+        for (const file of acceptedFiles) {
+          newFiles.push(file)
+        }
+        setFiles(newFiles)
+      }
     }
 
     // triggers when file is dropped


### PR DESCRIPTION
- Fixes an issue where the setFiles callback prop returned a function not an array of files.
- This worked fine if the `setFiles` was directly linked to a useState setter, but didn't work if it was a normal handler function. 