### PR TITLE
Fix/table row types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/Inputs/InputSwitch/InputSwitch.styled.ts
+++ b/src/Inputs/InputSwitch/InputSwitch.styled.ts
@@ -1,16 +1,20 @@
 import styled from 'styled-components'
 
 export const Switch = styled.div`
-  max-height: var(--base-input-size);
-  min-height: var(--base-input-size);
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
+  --bheight: calc(var(--base-input-size) * 0.7);
+  &.compact {
+    --bheight: calc(var(--base-input-size) * 0.6);
+  }
+  --bwidth: calc(var(--bheight) * 1.75);
+
+  max-height: var(--bheight);
+  min-height: var(--bheight);
 
   .switch-body {
-    --bheight: calc(var(--base-input-size) * 0.7);
-    --bwidth: calc(var(--bheight) * 1.75);
     position: relative;
     display: inline-block;
     height: var(--bheight);

--- a/src/Inputs/InputSwitch/InputSwitch.styled.ts
+++ b/src/Inputs/InputSwitch/InputSwitch.styled.ts
@@ -7,7 +7,7 @@ export const Switch = styled.div`
   justify-content: flex-start;
   --bheight: calc(var(--base-input-size) * 0.7);
   &.compact {
-    --bheight: calc(var(--base-input-size) * 0.6);
+    --bheight: calc(var(--base-input-size) * 0.55);
   }
   --bwidth: calc(var(--bheight) * 1.75);
 

--- a/src/Inputs/InputSwitch/InputSwitch.tsx
+++ b/src/Inputs/InputSwitch/InputSwitch.tsx
@@ -5,11 +5,15 @@ import * as Styled from './InputSwitch.styled'
 export interface InputSwitchProps extends InputHTMLAttributes<HTMLInputElement> {
   switchClassName?: string
   switchStyle?: CSSProperties
+  compact?: boolean
 }
 
 export const InputSwitch = forwardRef<HTMLInputElement, InputSwitchProps>(
-  ({ switchStyle, switchClassName, ...props }, ref) => (
-    <Styled.Switch style={switchStyle} className={`${switchClassName} ${props.className}`}>
+  ({ switchStyle, switchClassName, compact, ...props }, ref) => (
+    <Styled.Switch
+      style={switchStyle}
+      className={`${switchClassName} ${props.className} ${compact ? 'compact' : ''}`}
+    >
       <label className="switch-body">
         <input type="checkbox" {...props} ref={ref} />
         <span className="slider"></span>

--- a/src/Layout/TableRow/TableRow.stories.tsx
+++ b/src/Layout/TableRow/TableRow.stories.tsx
@@ -11,18 +11,61 @@ export default meta
 
 type Story = StoryObj<typeof TableRow>
 
+const rows = [
+  {
+    name: 'Description',
+    value: 'Some very long string that will be truncated',
+    tooltip: 'Say something amazing here!',
+    onCopy: () => console.log('copied'),
+    type: 'string',
+  },
+  {
+    name: 'Age',
+    value: 42,
+    type: 'number',
+  },
+  {
+    name: 'Is Active',
+    value: true,
+    type: 'boolean',
+  },
+  {
+    name: 'color',
+    value: ['red', 'green', 'blue'],
+    type: 'array',
+  },
+  {
+    name: 'custom',
+    children: (
+      <div
+        style={{ backgroundColor: 'var(--md-sys-color-on-primary)', padding: 4, borderRadius: 4 }}
+      >
+        Custom Div
+      </div>
+    ),
+  },
+]
+
 export const Default: Story = {
   render: () => (
     <Panel
       style={{
-        maxWidth: 200,
+        maxWidth: 300,
+        gap: 0,
       }}
     >
-      <TableRow
-        name="Description"
-        value="Some very long string that will be truncated"
-        tooltip="Say something amazing here!"
-      />
+      {rows.map((row, i) => (
+        <TableRow
+          key={i}
+          name={row.name}
+          value={row.value}
+          tooltip={row.tooltip}
+          onCopy={row.onCopy}
+          type={row.type}
+        >
+          {row.children}
+        </TableRow>
+      ))}
     </Panel>
   ),
 }

--- a/src/Layout/TableRow/TableRow.stories.tsx
+++ b/src/Layout/TableRow/TableRow.stories.tsx
@@ -44,6 +44,11 @@ const rows = [
       </div>
     ),
   },
+  {
+    name: 'birthday',
+    value: new Date().toISOString(),
+    type: 'date',
+  },
 ]
 
 export const Default: Story = {

--- a/src/Layout/TableRow/TableRow.styled.ts
+++ b/src/Layout/TableRow/TableRow.styled.ts
@@ -6,7 +6,7 @@ export const AttributeTableRow = styled.div`
   position: relative;
   justify-content: space-between;
   align-items: center;
-  padding: 3px 0;
+  padding: 6px 0;
   gap: 8px;
   border-top: 1px solid var(--md-sys-color-outline-variant);
   width: 100%;

--- a/src/Layout/TableRow/TableRow.tsx
+++ b/src/Layout/TableRow/TableRow.tsx
@@ -17,6 +17,7 @@ export const TableRow = forwardRef<HTMLDivElement, TableRowProps>(
     if (type === 'number') value = value?.toString()
     if (type === 'array') value = value?.join(', ')
     if (type === 'object') value = JSON.stringify(value)
+    if (type === 'date') value = new Date(value).toLocaleDateString()
 
     // check if there are any children
     const hasChildren = children !== undefined

--- a/src/Layout/TableRow/TableRow.tsx
+++ b/src/Layout/TableRow/TableRow.tsx
@@ -1,20 +1,38 @@
 import * as Styled from './TableRow.styled'
 import { OverflowField } from '../OverflowField'
 import { forwardRef } from 'react'
+import { InputSwitch } from '../../Inputs/InputSwitch'
 
 export interface TableRowProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onCopy'> {
   name?: string
-  value?: string | number | React.ReactNode
+  value?: any
   tooltip?: string
   onCopy?: (value: string) => void
+  type?: string
 }
 
 export const TableRow = forwardRef<HTMLDivElement, TableRowProps>(
-  ({ name, value, tooltip, onCopy, ...props }, ref) => {
+  ({ name, value, tooltip, type, onCopy, children, ...props }, ref) => {
+    type = type || typeof value
+    if (type === 'number') value = value?.toString()
+    if (type === 'array') value = value?.join(', ')
+    if (type === 'object') value = JSON.stringify(value)
+
+    // check if there are any children
+    const hasChildren = children !== undefined
+
     return (
       <Styled.AttributeTableRow ref={ref} {...props}>
         <Styled.Title $tooltip={tooltip}>{name}</Styled.Title>
-        {value ? <OverflowField value={value} onClick={onCopy} /> : '-'}
+        {!hasChildren &&
+          (type === 'boolean' ? (
+            <InputSwitch checked={value as boolean} disabled compact />
+          ) : value ? (
+            <OverflowField value={value} onClick={onCopy} />
+          ) : (
+            '-'
+          ))}
+        {children}
       </Styled.AttributeTableRow>
     )
   },


### PR DESCRIPTION
## Changelog Description

- `TableRow` now supports the types `string | number | array | object | boolean | date`. The is either automatically detected based off `typeOf value` or explicitly set with prop `type`.
- `TableRow` now supports children.
- `TableRow` type of `boolean` uses disabled compact switch.
-  `Switch` has new prop `compact: boolean` to make it slightly smaller.
- Bump `0.4.15`

## Additional Information

![image](https://github.com/ynput/ayon-react-components/assets/49156310/a6046140-2df5-4f58-b943-f7d4864ac3ea)
