### PR TITLE
TableRow: boolean check instead of switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/Layout/TableRow/TableRow.stories.tsx
+++ b/src/Layout/TableRow/TableRow.stories.tsx
@@ -27,6 +27,10 @@ const rows = [
     value: true,
   },
   {
+    name: 'Has Children',
+    value: false,
+  },
+  {
     name: 'color',
     value: ['red', 'green', 'blue'],
   },

--- a/src/Layout/TableRow/TableRow.tsx
+++ b/src/Layout/TableRow/TableRow.tsx
@@ -2,6 +2,7 @@ import * as Styled from './TableRow.styled'
 import { OverflowField } from '../OverflowField'
 import { forwardRef, isValidElement } from 'react'
 import { InputSwitch } from '../../Inputs/InputSwitch'
+import { Icon } from '../../Icon'
 
 export interface TableRowProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onCopy'> {
   name?: string
@@ -28,7 +29,7 @@ export const TableRow = forwardRef<HTMLDivElement, TableRowProps>(
         <Styled.Title $tooltip={tooltip}>{name}</Styled.Title>
         {!hasChildren &&
           (type === 'boolean' ? (
-            <InputSwitch checked={value as boolean} disabled compact />
+            <Icon icon={value ? 'check' : 'close'} />
           ) : value ? (
             <OverflowField value={value} onClick={onCopy} />
           ) : (


### PR DESCRIPTION
## Changelog Description

- Use a check and close icon for boolean attributes instead of a disabled switch.
- Bump 0.4.18