### PR TITLE
Dropdown: Animation rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "leaflet": "^1.8.0",
     "lint-staged": "^13.0.3",
     "material-symbols": "^0.10.1",
+    "overlayscrollbars": "^2.3.2",
+    "overlayscrollbars-react": "^0.5.2",
     "postcss": "^8.4.21",
     "prettier": "^2.7.1",
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.4.18",
+  "version": "0.5.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Dropdown, DropdownProps } from '.'
-import { useState } from 'react'
+import { Dropdown, DropdownProps, DropdownRef } from '.'
+import { useRef, useState } from 'react'
 import { Button } from '../../Button'
 import { IconType } from '../../Icon'
 import { InputText } from '../../Inputs/InputText'
@@ -32,6 +32,7 @@ const options: { value: IconType; keyword: string }[] = [
 
 const Template = (args: DropdownProps) => {
   const [value, setValue] = useState<(string | number)[]>(args.value || [options[0].value])
+  const dropdownRef = useRef<DropdownRef>(null)
 
   const handleClear = () => {
     // if minSelected is set, we need to set the value to the minSelected
@@ -57,8 +58,10 @@ const Template = (args: DropdownProps) => {
           width: 250,
           ...args.style,
         }}
+        ref={dropdownRef}
       />
       <InputText />
+      <Button label="Open dropdown" onClick={() => dropdownRef.current?.open()} />
     </Toolbar>
   )
 }
@@ -72,7 +75,6 @@ export const Icons: Story = {
     widthExpand: true,
     maxHeight: 180,
     onClear: undefined,
-    openOnFocus: true,
   },
   render: Template,
 }
@@ -101,7 +103,6 @@ export const Search: Story = {
     onClear: undefined,
     placeholder: 'Selected an Icon...',
     value: [],
-    openOnFocus: true,
   },
   render: Template,
 }

--- a/src/Dropdowns/Dropdown/Dropdown.styled.ts
+++ b/src/Dropdowns/Dropdown/Dropdown.styled.ts
@@ -1,3 +1,4 @@
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-react'
 import styled, { css, keyframes } from 'styled-components'
 
 export const Button = styled.button<{
@@ -136,27 +137,47 @@ export const Container = styled.div<{
     `}
 `
 
-export const Options = styled.ul<{
+type ScrollableProps = {
   $message: string
   $search: boolean
-}>`
+}
+
+export const Scrollable = styled(OverlayScrollbarsComponent)<ScrollableProps>`
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background-color: var(--md-sys-color-surface-container-low);
+  border-radius: ${({ $message, $search }) =>
+    $message || $search
+      ? '0 0 var(--border-radius-m) var(--border-radius-m)'
+      : 'var(--border-radius-m)'};
+
+  box-shadow: 0 1px 16px rgb(0 0 0 / 20%);
+
+  .os-scrollbar-handle {
+    background-color: var(--md-sys-color-surface-container-highest);
+    opacity: 0.75;
+
+    &:hover {
+      opacity: 1;
+      background-color: var(--md-sys-color-surface-container-highest);
+    }
+
+    &:active {
+      background-color: var(--md-sys-color-surface-container-highest-active);
+    }
+  }
+`
+
+export const Options = styled.ul`
   width: auto;
   list-style-type: none;
   padding: unset;
-  box-shadow: 0 2px 16px #0006;
 
   display: flex;
   flex-direction: column;
 
   margin: 0px;
-  border: 1px solid var(--md-sys-color-outline-variant);
-  background-color: var(--md-sys-color-surface-container-low);
+
   z-index: 20;
-  border-radius: ${({ $message, $search }) =>
-    $message || $search
-      ? '0 0 var(--border-radius-m) var(--border-radius-m)'
-      : 'var(--border-radius-m)'};
-  overflow: clip;
 
   position: relative;
 
@@ -167,20 +188,6 @@ export const Options = styled.ul<{
   /* move first child up by 1px to line up with list item (as it has no bottom border) */
   li:first-child {
     margin-top: -1px;
-  }
-
-  overflow-y: scroll;
-  /* scrollbar */
-  scrollbar-width: 8px;
-  &::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-    background: var(--md-sys-color-surface-container-low);
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--md-sys-color-outline);
-    border-radius: 8px;
   }
 `
 

--- a/src/Dropdowns/Dropdown/Dropdown.styled.ts
+++ b/src/Dropdowns/Dropdown/Dropdown.styled.ts
@@ -85,16 +85,23 @@ export const Dropdown = styled.div`
     height: 100%;
   }
 `
+export const dropdownMenuAnimation = () => keyframes`
+    0% {
+      scale: 0.95;
+    opacity: .6;
+  }
+  100% {
+    scale: 1;
+    opacity: 1;
+  }
+  `
 
 export const Container = styled.div<{
   $isOpen: boolean
-  $height?: number
   $message: string
-  $startAnimation: boolean
 }>`
   width: 100%;
   position: relative;
-  height: ${({ $height }) => `${$height}px`};
   width: auto;
   display: inline-block;
   height: min-content;
@@ -102,17 +109,11 @@ export const Container = styled.div<{
   position: fixed;
   z-index: 60;
 
-  /* position: fixed; */
-
-  /* hide when startAnimation false */
-  ${({ $startAnimation }) =>
-    !$startAnimation &&
-    css`
-      opacity: 0;
-    `}
+  animation: ${dropdownMenuAnimation()} 0.03s ease-in-out forwards;
+  transform-origin: top center;
 
   /* show warning when changing multiple entities */
-    ${({ $isOpen, $message }) =>
+  ${({ $isOpen, $message }) =>
     $isOpen &&
     $message &&
     css`
@@ -135,27 +136,14 @@ export const Container = styled.div<{
     `}
 `
 
-export const dropdownMenuAnimation = (end: number) => keyframes`
-    0% {
-      max-height: 0;
-      opacity: 0;
-  }
-  100% {
-      max-height: ${end}px;
-      opacity: 1;
-  }
-  `
-
 export const Options = styled.ul<{
   $message: string
   $search: boolean
-  $startAnimation: boolean
-  $animationHeight: number
-  $maxHeight?: number
 }>`
   width: auto;
   list-style-type: none;
   padding: unset;
+  box-shadow: 0 2px 16px #0006;
 
   display: flex;
   flex-direction: column;
@@ -181,19 +169,6 @@ export const Options = styled.ul<{
     margin-top: -1px;
   }
 
-  /* play animation on $startAnimation */
-  ${({ $startAnimation, $animationHeight, $maxHeight }) =>
-    $maxHeight &&
-    ($startAnimation
-      ? css`
-          animation: ${dropdownMenuAnimation($animationHeight)} 0.1s ease-in-out forwards;
-          max-height: ${$maxHeight}px;
-        `
-      : css`
-          opacity: 0;
-          max-height: ${$maxHeight}px;
-        `)}
-
   overflow-y: scroll;
   /* scrollbar */
   scrollbar-width: 8px;
@@ -209,21 +184,9 @@ export const Options = styled.ul<{
   }
 `
 
-export const slideDown = keyframes`
-    0% {
-      transform: translateY(-100%);
-      opacity: 0;
-  }
-  100% {
-      transform: translateY(0);
-      opacity: 1;
-  }
-  `
-
 export const ListItem = styled.li<{
   $focused: boolean
   $usingKeyboard: boolean
-  $startAnimation: boolean
   $disabled?: boolean
 }>`
   cursor: pointer;
@@ -262,13 +225,6 @@ export const ListItem = styled.li<{
         outline-offset: -1px;
         border-radius: var(--border-radius-m);
       }
-    `}
-
-  /* start animation, slide down 100% height */
-        ${({ $startAnimation }) =>
-    $startAnimation &&
-    css`
-      animation: ${slideDown} 0.1s ease-in-out forwards;
     `}
 `
 
@@ -319,14 +275,5 @@ export const Search = styled.div`
       outline-offset: -1px;
       z-index: 30;
     }
-
-    opacity: 0;
-    /* $startAnimation transition opacity 0 to 1 */
-    ${({ $startAnimation }: { $startAnimation: boolean }) =>
-      $startAnimation &&
-      css`
-        transition: opacity 0.05;
-        opacity: 1;
-      `}
   }
 `

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -9,6 +9,7 @@ import { Icon, IconType } from '../../Icon'
 import { DefaultValueTemplate } from '.'
 import TagsValueTemplate from './TagsValueTemplate'
 import 'overlayscrollbars/overlayscrollbars.css'
+import { createPortal } from 'react-dom'
 
 /**
  * Hook that alerts clicks outside of the passed ref
@@ -640,93 +641,96 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
             )}
           </Styled.Button>
         )}
-        {!!isShowOptions && (
-          <Styled.Container
-            style={{
-              left: pos?.left || 'unset',
-              right: pos?.right || 'unset',
-              top: pos?.y || 'unset',
-              ...itemStyle,
-            }}
-            $message={message || ''}
-            $isOpen={true}
-            onSubmit={handleSearchSubmit}
-            ref={formRef}
-          >
-            {(search || editable) && (
-              <Styled.Search className="search">
-                <Icon icon={'search'} />
-                <InputText
-                  value={searchForm}
-                  onChange={(e) => setSearchForm(e.target.value)}
-                  autoFocus
-                  tabIndex={0}
-                  ref={searchRef}
-                  onKeyDown={(e) => e.code === 'Enter' && e.preventDefault()}
-                />
-              </Styled.Search>
-            )}
-            <Styled.Scrollable
-              style={{ maxHeight }}
+
+        {!!isShowOptions &&
+          createPortal(
+            <Styled.Container
+              style={{
+                left: pos?.left || 'unset',
+                right: pos?.right || 'unset',
+                top: pos?.y || 'unset',
+                ...itemStyle,
+              }}
               $message={message || ''}
-              $search={!!search || !!editable}
-              defer
+              $isOpen={true}
+              onSubmit={handleSearchSubmit}
+              ref={formRef}
             >
-              <Styled.Options
-                style={{ minWidth, ...listStyle }}
-                className={'options'}
-                ref={optionsRef}
-              >
-                {showOptions.map((option, i) => (
-                  <Styled.ListItem
-                    key={`${option[dataKey]}-${i}`}
-                    onClick={(e) =>
-                      !disabledValues.includes(option[dataKey]) &&
-                      handleChange(option[dataKey], i, e)
-                    }
-                    $focused={usingKeyboard && activeIndex === i}
-                    $usingKeyboard={usingKeyboard}
+              {(search || editable) && (
+                <Styled.Search className="search">
+                  <Icon icon={'search'} />
+                  <InputText
+                    value={searchForm}
+                    onChange={(e) => setSearchForm(e.target.value)}
+                    autoFocus
                     tabIndex={0}
-                    className={`option ${listClassName}`}
-                    $disabled={disabledValues.includes(option[dataKey])}
-                  >
-                    {itemTemplate ? (
-                      itemTemplate(
-                        option,
-                        value.includes(option[dataKey]),
-                        selected.includes(option[dataKey]),
-                        i,
-                      )
-                    ) : (
-                      <Styled.DefaultItem
-                        $isSelected={selected.includes(option[dataKey])}
-                        className={`option-child ${
-                          value.includes(option[dataKey]) ? 'selected' : ''
-                        } ${value.includes(option[dataKey]) ? 'active' : ''} ${itemClassName}`}
-                        style={itemStyle}
-                      >
-                        {option.icon && <Icon icon={option.icon} />}
-                        <span>{option[labelKey] || option[dataKey]}</span>
+                    ref={searchRef}
+                    onKeyDown={(e) => e.code === 'Enter' && e.preventDefault()}
+                  />
+                </Styled.Search>
+              )}
+              <Styled.Scrollable
+                style={{ maxHeight }}
+                $message={message || ''}
+                $search={!!search || !!editable}
+                defer
+              >
+                <Styled.Options
+                  style={{ minWidth, ...listStyle }}
+                  className={'options'}
+                  ref={optionsRef}
+                >
+                  {showOptions.map((option, i) => (
+                    <Styled.ListItem
+                      key={`${option[dataKey]}-${i}`}
+                      onClick={(e) =>
+                        !disabledValues.includes(option[dataKey]) &&
+                        handleChange(option[dataKey], i, e)
+                      }
+                      $focused={usingKeyboard && activeIndex === i}
+                      $usingKeyboard={usingKeyboard}
+                      tabIndex={0}
+                      className={`option ${listClassName}`}
+                      $disabled={disabledValues.includes(option[dataKey])}
+                    >
+                      {itemTemplate ? (
+                        itemTemplate(
+                          option,
+                          value.includes(option[dataKey]),
+                          selected.includes(option[dataKey]),
+                          i,
+                        )
+                      ) : (
+                        <Styled.DefaultItem
+                          $isSelected={selected.includes(option[dataKey])}
+                          className={`option-child ${
+                            value.includes(option[dataKey]) ? 'selected' : ''
+                          } ${value.includes(option[dataKey]) ? 'active' : ''} ${itemClassName}`}
+                          style={itemStyle}
+                        >
+                          {option.icon && <Icon icon={option.icon} />}
+                          <span>{option[labelKey] || option[dataKey]}</span>
+                        </Styled.DefaultItem>
+                      )}
+                    </Styled.ListItem>
+                  ))}
+                  {!!hiddenLength && (
+                    <Styled.ListItem
+                      onClick={handleShowMore}
+                      $focused={false}
+                      $usingKeyboard={false}
+                      className="option"
+                    >
+                      <Styled.DefaultItem $isSelected={false} className="option-child hidden">
+                        <span>{`Show ${50} more...`}</span>
                       </Styled.DefaultItem>
-                    )}
-                  </Styled.ListItem>
-                ))}
-                {!!hiddenLength && (
-                  <Styled.ListItem
-                    onClick={handleShowMore}
-                    $focused={false}
-                    $usingKeyboard={false}
-                    className="option"
-                  >
-                    <Styled.DefaultItem $isSelected={false} className="option-child hidden">
-                      <span>{`Show ${50} more...`}</span>
-                    </Styled.DefaultItem>
-                  </Styled.ListItem>
-                )}
-              </Styled.Options>
-            </Styled.Scrollable>
-          </Styled.Container>
-        )}
+                    </Styled.ListItem>
+                  )}
+                </Styled.Options>
+              </Styled.Scrollable>
+            </Styled.Container>,
+            document.body,
+          )}
       </Styled.Dropdown>
     )
   },

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -162,10 +162,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
       left?: number | null
       right?: number | null
       y: number | null
-    }>({ left: null, right: null, y: 0 })
-    const [startAnimation, setStartAnimation] = useState(false)
-    const [startAnimationFinished, setStartAnimationFinished] = useState(false)
-    const [optionsHeight, setOptionsHeight] = useState(0)
+    }>({ left: null, right: null, y: null })
     const [minWidth, setMinWidth] = useState(0)
     // search
     const [searchForm, setSearchForm] = useState('')
@@ -193,21 +190,18 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
     // USE EFFECTS
     // sets the correct position and height
     useEffect(() => {
-      if (isOpen && valueRef.current && optionsRef.current) {
+      if (isOpen && valueRef.current) {
         const valueRec = valueRef.current.getBoundingClientRect()
         const valueWidth = valueRec.width
         const valueHeight = valueRec.height
-
-        const optionsRec = optionsRef.current.getBoundingClientRect()
-        const optionsHeight = optionsRec.height
 
         const left = valueRec.x
         const right = window.innerWidth - valueRec.x - valueWidth
         let y = valueRec.y + (listInline ? 0 : valueHeight)
 
         // check it's not vertically off screen
-        if (optionsHeight + y + 20 > window.innerHeight) {
-          y = window.innerHeight - optionsHeight - 20
+        if (maxHeight + y + 20 > window.innerHeight) {
+          y = window.innerHeight - maxHeight - 20
         }
 
         if (align === 'right') {
@@ -218,16 +212,8 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
         }
 
         if (widthExpand) setMinWidth(valueWidth)
-
-        // console.log(optionsHeight)
-
-        // then start animation
-        setStartAnimation(true)
-        setOptionsHeight(optionsHeight)
-      } else {
-        setStartAnimation(false)
       }
-    }, [isOpen, valueRef, optionsRef, setMinWidth, setStartAnimation, setPos])
+    }, [isOpen, valueRef, setMinWidth, setPos])
 
     // set initial selected from value
     useEffect(() => {
@@ -321,8 +307,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
 
       // close dropdown
       setIsOpen(false)
-      // reset animation
-      setStartAnimationFinished(false)
 
       // reset keyboard
       setActiveIndex(null)
@@ -599,7 +583,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
       style: valueStyle,
       placeholder,
       isOpen,
-      setStartAnimationFinished,
       className: valueClassName,
     }
 
@@ -653,7 +636,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
             )}
           </Styled.Button>
         )}
-        {isOpen && options && (
+        {isOpen && options && (pos.y || pos.y === 0) && (
           <Styled.Container
             style={{
               left: pos?.left || 'unset',
@@ -664,11 +647,10 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
             $message={message || ''}
             $isOpen={true}
             onSubmit={handleSearchSubmit}
-            $startAnimation={startAnimation}
             ref={formRef}
           >
             {(search || editable) && (
-              <Styled.Search $startAnimation={startAnimation} className="search">
+              <Styled.Search className="search">
                 <Icon icon={'search'} />
                 <InputText
                   value={searchForm}
@@ -684,11 +666,7 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
               $message={message || ''}
               $search={!!search || !!editable}
               ref={optionsRef}
-              style={{ minWidth, ...listStyle }}
-              $startAnimation={startAnimation}
-              $animationHeight={optionsHeight}
-              $maxHeight={maxHeight}
-              onAnimationEnd={() => setStartAnimationFinished(true)}
+              style={{ minWidth, maxHeight, ...listStyle }}
               className={'options'}
             >
               {showOptions.map((option, i) => (
@@ -699,9 +677,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
                   }
                   $focused={usingKeyboard && activeIndex === i}
                   $usingKeyboard={usingKeyboard}
-                  $startAnimation={
-                    startAnimation && !startAnimationFinished && (search || editable || i !== 0)
-                  }
                   tabIndex={0}
                   className={`option ${listClassName}`}
                   $disabled={disabledValues.includes(option[dataKey])}
@@ -732,7 +707,6 @@ export const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
                   onClick={handleShowMore}
                   $focused={false}
                   $usingKeyboard={false}
-                  $startAnimation={startAnimation}
                   className="option"
                 >
                   <Styled.DefaultItem $isSelected={false} className="option-child hidden">

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -205,7 +205,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
 
         const left = valueRec.x
         const right = window.innerWidth - valueRec.x - valueWidth
-        let y = valueRec.y + (listInline ? 0 : valueHeight)
+        let y = valueRec.y + (listInline ? 0 : valueHeight) - 1
 
         // check it's not vertically off screen
         if (maxHeight + y + 20 > window.innerHeight) {


### PR DESCRIPTION
## Changelog Description

- Changed the animation to be simpler and faster.
- Use `createPortal` to place open options dialog inside of `document.body` so that it's always on top and never cutoff.
- Use custom overlay scrollbar.
- BREAKING: Removed `openOnFocus` prop.
- BREAKING: `ref` prop changed to expose `getElement`, `getOptions`, `open` and `hide`.
- Bump: `0.5.0`

```typescript
export interface DropdownRef {
  getElement: () => HTMLDivElement | null
  getOptions: () => HTMLUListElement | null
  open: () => void
  close: () => void
}
```

 ## Additional Information
 
![dropdown_open_button_v001](https://github.com/ynput/ayon-react-components/assets/49156310/36c42477-68b0-4ef2-999e-9354f055af9f)
