### PR TITLE
Enhancement: dropdown null and invalid values

### DIFF
--- a/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
@@ -28,7 +28,7 @@ const DefaultValueStyled = styled.div`
     ${({ $isOpen }: { $isOpen: boolean }) =>
       $isOpen &&
       css`
-        &:not(#clear) {
+        &:not(#clear):not(#backspace) {
           transform: rotate(180deg);
         }
       `}
@@ -52,7 +52,13 @@ const ContentStyled = styled.div`
 export interface DefaultValueTemplateProps
   extends Pick<
     DropdownProps,
-    'value' | 'isMultiple' | 'dropIcon' | 'onClear' | 'onClearNoValue' | 'placeholder'
+    | 'value'
+    | 'isMultiple'
+    | 'dropIcon'
+    | 'onClear'
+    | 'onClearNullValue'
+    | 'nullPlaceholder'
+    | 'placeholder'
   > {
   displayIcon?: string
   style?: React.CSSProperties
@@ -69,7 +75,8 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
   dropIcon = 'expand_more',
   displayIcon,
   onClear,
-  onClearNoValue,
+  onClearNullValue,
+  nullPlaceholder,
   children,
   style,
   valueStyle,
@@ -80,15 +87,42 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
 }) => {
   const noValue = !value?.length
 
+  const handleOnClearClick = (value: null | []) => {
+    onClear && onClear(value)
+  }
+
   return (
     <DefaultValueStyled style={style} $isOpen={!!isOpen} className={className}>
       {noValue ? (
         <>
           <ContentStyled>
-            <ValueStyled>{placeholder}</ValueStyled>
+            <ValueStyled style={{ opacity: 0.5 }}>
+              {value === null
+                ? nullPlaceholder || '(no value)'
+                : onClearNullValue
+                ? '(empty list)'
+                : placeholder}
+            </ValueStyled>
           </ContentStyled>
-          {onClear && onClearNoValue && (
-            <Icon icon={'close'} onClick={onClear} id="clear" className="control" tabIndex={0} />
+          {onClear && onClearNullValue && (
+            <>
+              <Icon
+                icon={'backspace'}
+                onClick={() => handleOnClearClick(null)}
+                id={'backspace'}
+                className="control"
+                tabIndex={0}
+                data-tooltip={'Clear to NULL'}
+              />
+              <Icon
+                icon={'close'}
+                onClick={() => handleOnClearClick([])}
+                id={'clear'}
+                className="control"
+                tabIndex={0}
+                data-tooltip={'Clear to empty list'}
+              />
+            </>
           )}
         </>
       ) : (
@@ -99,8 +133,25 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
             <ValueStyled style={valueStyle}>{children}</ValueStyled>
             {isMultiple && <span>{`)`}</span>}
           </ContentStyled>
+          {onClear && onClearNullValue && (
+            <Icon
+              icon={'backspace'}
+              onClick={() => handleOnClearClick(null)}
+              id={'backspace'}
+              className="control"
+              tabIndex={0}
+              data-tooltip={'Clear to NULL'}
+            />
+          )}
           {onClear && (
-            <Icon icon={'close'} onClick={onClear} id="clear" className="control" tabIndex={0} />
+            <Icon
+              icon={'close'}
+              onClick={() => handleOnClearClick([])}
+              id="clear"
+              className="control"
+              tabIndex={0}
+              data-tooltip={'Clear to empty list'}
+            />
           )}
         </>
       )}

--- a/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
@@ -78,7 +78,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
   className,
   childrenCustom,
 }) => {
-  const noValue = !value.length
+  const noValue = !value?.length
 
   return (
     <DefaultValueStyled style={style} $isOpen={!!isOpen} className={className}>

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -32,7 +32,9 @@ const options: { value: IconType; keyword: string }[] = [
 ]
 
 const Template = (args: DropdownProps) => {
-  const [value, setValue] = useState<(string | number)[]>(args.value || [options[0].value])
+  const [value, setValue] = useState<(string | number)[] | null>(
+    args.value === undefined ? [options[0].value] : args.value,
+  )
   const dropdownRef = useRef<DropdownRef>(null)
 
   const handleClear = () => {
@@ -199,4 +201,15 @@ export const Scrolled: Story = {
       </Panel>
     )
   },
+}
+
+// simple dropdown with 1000 items and search
+export const InvalidValue: Story = {
+  args: {
+    placeholder: 'Select a value...',
+    onClear: () => console.log('clear'),
+    value: null,
+    multiSelect: true,
+  },
+  render: Template,
 }

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -37,12 +37,6 @@ const Template = (args: DropdownProps) => {
   )
   const dropdownRef = useRef<DropdownRef>(null)
 
-  const handleClear = () => {
-    // if minSelected is set, we need to set the value to the minSelected
-    const newValue = args.minSelected ? options.slice(0, args.minSelected).map((o) => o.value) : []
-    setValue(newValue)
-  }
-
   const handleChange = (v: (string | number)[]) => {
     console.log(v)
     setValue(v)
@@ -55,7 +49,7 @@ const Template = (args: DropdownProps) => {
         value={value}
         onChange={handleChange}
         options={args.options || options}
-        onClear={args.onClear && handleClear}
+        onClear={args.onClear && setValue}
         widthExpand
         style={{
           width: 250,
@@ -208,8 +202,10 @@ export const InvalidValue: Story = {
   args: {
     placeholder: 'Select a value...',
     onClear: () => console.log('clear'),
+    onClearNullValue: true,
     value: null,
     multiSelect: true,
+    nullPlaceholder: 'No value (custom placeholder)',
   },
   render: Template,
 }

--- a/src/Dropdowns/Dropdown/Dropdown.styled.ts
+++ b/src/Dropdowns/Dropdown/Dropdown.styled.ts
@@ -77,6 +77,7 @@ export const Dropdown = styled.div`
   height: 32px;
   /* width: 100%; */
   display: inline-block;
+  overflow: hidden;
 
   button {
     width: 100%;

--- a/src/Dropdowns/Dropdown/TagsValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/TagsValueTemplate.tsx
@@ -17,7 +17,7 @@ const TagsValueTemplate: FC<Omit<DefaultValueTemplateProps, 'children'>> = (prop
       valueStyle={{ gap: 4, display: 'flex' }}
       style={{ padding: '0 4px' }}
     >
-      {value.map((v) => (
+      {value?.map((v) => (
         <TagStyled key={v}>{v}</TagStyled>
       ))}
     </DefaultValueTemplate>


### PR DESCRIPTION
## Changelog Description

- BREAKING: `onClearNoValue` renamed to `onClearNullValue` and behaviour changed to enable/disable setting value as `null`.
- Dropdown now supports null values and will show a default `(no value)` placeholder unless a custom one is provided.
- `onClearNullValue` along with `onClear` reveals new backspace icon to set the value to `null` instead of the default clear value of `[]`
- `nullPlaceholder` prop allows for custom null placeholder text.
- `onClear` function prop will now provide a clearing value of either `null` or `[]` 

https://github.com/ynput/ayon-react-components/assets/49156310/37a4ebae-c8ae-4e5b-8fe4-57ab6be7efd8

