### PR TITLE
Fix: Dropdown separate clear null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
@@ -56,7 +56,7 @@ export interface DefaultValueTemplateProps
     | 'isMultiple'
     | 'dropIcon'
     | 'onClear'
-    | 'onClearNullValue'
+    | 'onClearNull'
     | 'nullPlaceholder'
     | 'placeholder'
   > {
@@ -75,7 +75,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
   dropIcon = 'expand_more',
   displayIcon,
   onClear,
-  onClearNullValue,
+  onClearNull,
   nullPlaceholder,
   children,
   style,
@@ -87,10 +87,6 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
 }) => {
   const noValue = !value?.length
 
-  const handleOnClearClick = (value: null | []) => {
-    onClear && onClear(value)
-  }
-
   return (
     <DefaultValueStyled style={style} $isOpen={!!isOpen} className={className}>
       {noValue ? (
@@ -99,30 +95,30 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
             <ValueStyled style={{ opacity: 0.5 }}>
               {value === null
                 ? nullPlaceholder || '(no value)'
-                : onClearNullValue
+                : onClearNull
                 ? '(empty list)'
                 : placeholder}
             </ValueStyled>
           </ContentStyled>
-          {onClear && onClearNullValue && (
-            <>
-              <Icon
-                icon={'backspace'}
-                onClick={() => handleOnClearClick(null)}
-                id={'backspace'}
-                className="control"
-                tabIndex={0}
-                data-tooltip={'Clear to NULL'}
-              />
-              <Icon
-                icon={'close'}
-                onClick={() => handleOnClearClick([])}
-                id={'clear'}
-                className="control"
-                tabIndex={0}
-                data-tooltip={'Clear to empty list'}
-              />
-            </>
+          {onClearNull && (
+            <Icon
+              icon={'backspace'}
+              onClick={() => onClearNull(null)}
+              id={'backspace'}
+              className="control"
+              tabIndex={0}
+              data-tooltip={'Set to Inherit (null)'}
+            />
+          )}
+          {onClear && (
+            <Icon
+              icon={'close'}
+              onClick={() => onClear([])}
+              id={'clear'}
+              className="control"
+              tabIndex={0}
+              data-tooltip={'Clear to empty list'}
+            />
           )}
         </>
       ) : (
@@ -133,20 +129,20 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
             <ValueStyled style={valueStyle}>{children}</ValueStyled>
             {isMultiple && <span>{`)`}</span>}
           </ContentStyled>
-          {onClear && onClearNullValue && (
+          {onClearNull && (
             <Icon
               icon={'backspace'}
-              onClick={() => handleOnClearClick(null)}
+              onClick={() => onClearNull(null)}
               id={'backspace'}
               className="control"
               tabIndex={0}
-              data-tooltip={'Clear to NULL'}
+              data-tooltip={'Set to Inherit (null)'}
             />
           )}
           {onClear && (
             <Icon
               icon={'close'}
-              onClick={() => handleOnClearClick([])}
+              onClick={() => onClear([])}
               id="clear"
               className="control"
               tabIndex={0}

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -50,6 +50,7 @@ const Template = (args: DropdownProps) => {
         onChange={handleChange}
         options={args.options || options}
         onClear={args.onClear && setValue}
+        onClearNull={args.onClearNull && setValue}
         widthExpand
         style={{
           width: 250,
@@ -201,8 +202,8 @@ export const Scrolled: Story = {
 export const InvalidValue: Story = {
   args: {
     placeholder: 'Select a value...',
-    onClear: () => console.log('clear'),
-    onClearNullValue: true,
+    onClearNull: () => console.log('clear null'),
+    onClear: undefined,
     value: null,
     multiSelect: true,
     nullPlaceholder: 'No value (custom placeholder)',

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -82,8 +82,8 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   minSelected?: number
   maxSelected?: number
   dropIcon?: IconType
-  onClear?: (value: null | []) => void
-  onClearNullValue?: boolean // show clear button when no value and changes icon to clear null
+  onClear?: (value: []) => void
+  onClearNull?: (value: null) => void
   nullPlaceholder?: string
   editable?: boolean
   maxHeight?: number
@@ -140,7 +140,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       maxSelected,
       dropIcon = 'expand_more',
       onClear,
-      onClearNullValue,
+      onClearNull,
       nullPlaceholder,
       editable,
       maxHeight = 300,
@@ -420,14 +420,19 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       }
     }
 
-    const handleClear = (value: null | []) => {
+    const handleClear = () => {
       if (!onClear) return
 
-      if ((selected?.length || 0) > minSelected || onClearNullValue) {
-        setSelected([])
-        onClear(value)
-        setIsOpen(false)
-      }
+      setSelected([])
+      onClear([])
+      setIsOpen(false)
+    }
+    const handleClearNull = () => {
+      if (!onClearNull) return
+
+      setSelected([])
+      onClearNull(null)
+      setIsOpen(false)
     }
 
     const handleOpen = (
@@ -437,10 +442,10 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       // check if onClear was clicked
       if ((e.target as HTMLDivElement).id === 'clear') {
         if (focus) return
-        else return handleClear([])
+        else return handleClear()
       } else if ((e.target as HTMLDivElement).id === 'backspace') {
         if (focus) return
-        else return handleClear(null)
+        else return handleClearNull()
       }
       if (isOpen) {
         return handleClose()
@@ -520,9 +525,9 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
         if (!isOpen) {
           // check not clear button
           if ((e.target as HTMLDivElement).id === 'clear') {
-            return handleClear([])
+            return handleClear()
           } else if ((e.target as HTMLDivElement).id === 'backspace') {
-            return handleClear(null)
+            return handleClearNull()
           }
           return setIsOpen(true)
         }
@@ -531,7 +536,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
           selectedValue && handleChange(selectedValue, activeIndex || 0)
 
           // nothing selected and only one option and not nullable
-          if (options.length === 1 || (options.length === 2 && editable && !onClearNullValue)) {
+          if (options.length === 1 || (options.length === 2 && editable && !onClearNull)) {
             handleClose(undefined, selected ? [...selected] : [], options[0][dataKey])
           }
         } else {
@@ -603,8 +608,8 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       isMultiple,
       dropIcon,
       displayIcon,
-      onClear: onClear ? handleClear : undefined,
-      onClearNullValue,
+      onClear: onClear && handleClear,
+      onClearNull: onClearNull && handleClearNull,
       nullPlaceholder,
       style: valueStyle,
       placeholder,
@@ -622,7 +627,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       value,
       isOpen,
       onClear,
-      onClearNullValue,
+      onClearNull,
       selected,
       handleClear,
       isMultiple,

--- a/src/Dropdowns/IconSelect/IconSelect.tsx
+++ b/src/Dropdowns/IconSelect/IconSelect.tsx
@@ -13,10 +13,10 @@ export interface IconTemplateProps {
 const IconTemplate = ({ value, valueTemplate, isActive, isSelected }: IconTemplateProps) => {
   return (
     <Styled.Icon $valueTemplate={valueTemplate} $isActive={isSelected}>
-      {value.map((icon) => (
+      {value?.map((icon) => (
         <Icon key={icon} icon={icon as IconType} />
       ))}
-      {value.length < 2 && <span>{value}</span>}
+      {value && value.length < 2 && <span>{value}</span>}
     </Styled.Icon>
   )
 }

--- a/src/Dropdowns/SortingDropdown/SortingDropdown.tsx
+++ b/src/Dropdowns/SortingDropdown/SortingDropdown.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { DefaultValueTemplate, Dropdown, DropdownProps } from '../Dropdown'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import SortCard from './SortCard'
 
 const StyledDropdown = styled(Dropdown)`
@@ -38,7 +38,7 @@ export const SortingDropdown: FC<SortingDropdownProps> = ({
 }) => {
   const handleChange = (v: DropdownProps['value']) => {
     // for each value, find in value, if not found, find in options and add sortOrder
-    const newValues = v.map((id) => {
+    const newValues = v?.map((id) => {
       const idx = value.findIndex((v) => v.id === id)
       if (idx === -1) {
         const option = options.find((o) => o.id === id)
@@ -55,7 +55,7 @@ export const SortingDropdown: FC<SortingDropdownProps> = ({
       }
     })
 
-    onChange(newValues)
+    onChange(newValues ?? [])
   }
 
   const handleSortChange = (id: string) => {

--- a/src/Dropdowns/TagsSelect/TagsSelectValueTemplate.tsx
+++ b/src/Dropdowns/TagsSelect/TagsSelectValueTemplate.tsx
@@ -12,11 +12,11 @@ export const TagsSelectValueTemplate: FC<TagsSelectValueTemplateProps> = (props)
   const { value, tags = {}, editor = false } = props
 
   //   if value empty return placeholder tag
-  if (!value.length) value.push('Add tags')
+  if (!value?.length) value?.push('Add tags')
 
   return (
     <Styled.TagsValueTemplate {...props} valueStyle={{ gap: 4, display: 'flex' }} editor={editor}>
-      {value.map((v) => (
+      {value?.map((v) => (
         <Styled.Tag
           key={v}
           style={{


### PR DESCRIPTION
## Changelog Description

- `onClear` and `onClearNull` now operate independently. So you can have either one or both.
- Type fixes.