### PR TITLE
Dropdown onSelectionChange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ynput/ayon-react-components",
   "private": false,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -210,3 +210,35 @@ export const InvalidValue: Story = {
   },
   render: Template,
 }
+
+// outside state synced to dropdown state
+export const SyncedState: Story = {
+  args: {},
+  render: (args: DropdownProps) => {
+    const [value, setValue] = useState<(string | number)[] | null>([])
+    const [liveValue, setLiveValue] = useState<(string | number)[] | null>([])
+
+    const handleChange = (v: (string | number)[] | null) => {
+      setValue(v)
+      setLiveValue(v)
+    }
+
+    return (
+      <>
+        <Dropdown
+          value={value}
+          multiSelect
+          onSelectionChange={(v) => setLiveValue(v)}
+          onChange={handleChange}
+          options={args.options || options}
+          widthExpand
+          style={{
+            width: 250,
+            ...args.style,
+          }}
+        />
+        <span>{liveValue?.join(', ')}</span>
+      </>
+    )
+  },
+}

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -70,6 +70,7 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   isChanged?: boolean
   isMultiple?: boolean
   onChange?: (v: (string | number)[]) => void
+  onSelectionChange?: (v: (string | number)[]) => void
   maxOptionsShown?: number
   style?: CSSProperties
   className?: string
@@ -119,6 +120,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       disabled,
       onClose,
       onChange,
+      onSelectionChange,
       onOpen,
       widthExpand = true,
       align = 'left',
@@ -409,6 +411,9 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
         // focus on search
         searchRef.current?.focus()
       }
+
+      // send on selection changed event
+      onSelectionChange && onSelectionChange(newSelected)
 
       // update temp value
       // update state


### PR DESCRIPTION
## Changelog Description

- New prop `onSelectionChange` prop that works the same way as `onChange` but fires every time the selection changes, even before the dropdown has closed.
- Bump: version 0.5.7