### PR TITLE
Fix: Added name prop to UserImage, UserImagesStacked and AssigneeDrop…

### DIFF
--- a/src/Dropdowns/AssigneeSelect/AssigneeDropdownTemplate.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeDropdownTemplate.tsx
@@ -35,7 +35,7 @@ export const AssigneeDropdownTemplate = ({
 }: AssigneeDropdownProps) => {
   return (
     <RowStyled {...{ isSelected, onClick }}>
-      <UserImage src={avatarUrl} fullName={fullName || name} size={size} />
+      <UserImage src={avatarUrl} fullName={fullName} name={name} size={size} />
       {fullName || name}
     </RowStyled>
   )

--- a/src/User/UserImage/UserImage.stories.tsx
+++ b/src/User/UserImage/UserImage.stories.tsx
@@ -16,10 +16,12 @@ const randomUserNumber = Math.floor(Math.random() * 90) + 10
 export const Default: Story = {
   args: {
     src: `https://repo.imm.cz/avatars/demouser${randomUserNumber}.jpg`,
+    name: 'John'
   },
 }
 export const Initials: Story = {
   args: {
     fullName: 'Demo User',
+    name: 'John'
   },
 }

--- a/src/User/UserImage/UserImage.tsx
+++ b/src/User/UserImage/UserImage.tsx
@@ -4,27 +4,31 @@ import * as Styled from './UserImage.styled'
 export interface UserImageProps extends React.HTMLAttributes<HTMLSpanElement> {
   src?: string
   fullName?: string
+  name: string
   size?: number
   highlight?: boolean
 }
 
 export const UserImage = forwardRef<HTMLSpanElement, UserImageProps>(
-  ({ src, fullName, size = 30, highlight, className, ...props }, ref) => {
-    const fontSize = Math.round((13 / 30) * size)
+  ({ src, name, fullName, size = 30, highlight, className, ...props }, ref) => {
+    const fontSize = Math.round((13 / 30) * size)  
+    const nameData = fullName || name
+    const hasNameData = !!nameData
 
-    const initials = fullName
-      ?.split(' ')
-      .map((w) => w[0]?.toUpperCase())
-      .splice(0, 2)
-      .join('')
+    const createInitials = (nameData: string) => {
+      // regex handles different type of whitespaces 
+      const words = nameData.trim().split(/\s+/)
+      const mappedInitials = words.slice(0, 2).map(word => word[0].toUpperCase()).join('')
+      return mappedInitials;
+    }
+    const initials = hasNameData ? createInitials(nameData) : 'N/A'
 
     return (
       <Styled.CircleImage
         style={{ width: size, maxHeight: size, minHeight: size, ...props.style }}
         $highlight={highlight}
         ref={ref}
-        className={`${className ? className : ''} ${src ? '' : 'initials'} user-image
-        `}
+        className={`${className ? className : ''} ${src ? '' : 'initials'} user-image`}
         {...props}
       >
         {src ? <img src={src} /> : <span style={{ fontSize: `${fontSize}px` }}>{initials}</span>}

--- a/src/User/UserImagesStacked/UserImagesStacked.stories.tsx
+++ b/src/User/UserImagesStacked/UserImagesStacked.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof UserImagesStacked>
 const users = Array.from({ length: 10 }, (_, i) => ({
   avatarUrl: `https://repo.imm.cz/avatars/demouser${i + 10}.jpg`,
   fullName: `User ${i + 1}`,
+  name: `Name ${i + 1}`,
   self: i === 0,
 }))
 

--- a/src/User/UserImagesStacked/UserImagesStacked.tsx
+++ b/src/User/UserImagesStacked/UserImagesStacked.tsx
@@ -14,6 +14,7 @@ const StackedStyled = styled.div`
 export interface User {
   avatarUrl?: string
   fullName?: string
+  name: string
   self?: boolean
 }
 
@@ -33,18 +34,22 @@ export const UserImagesStacked = forwardRef<HTMLDivElement, UserImagesStackedPro
 
     // show extras
     if (length > max) {
-      users.push({ fullName: `+ ${length - max > 9 ? '+' : length - max}` })
+      users.push({
+        fullName: `+ ${length - max > 9 ? '+' : length - max}`,
+        name: `+ ${length - max > 9 ? '+' : length - max}`
+      })
     }
 
     return (
       <StackedStyled $gap={(gap * 30) / 2} {...props} ref={ref}>
-        {users.map((user, i) => (
+        {users.map(({ avatarUrl, name, fullName, self }, i) => (
           <UserImage
-            src={user.avatarUrl}
+            src={avatarUrl}
             key={i}
-            fullName={user.fullName || ''}
+            name={name}
+            fullName={fullName || ''}
             style={{ zIndex: -i, width: size, height: size, ...userStyle }}
-            highlight={user.self}
+            highlight={self}
             size={size}
           />
         ))}


### PR DESCRIPTION
## Changelog description

- fixed issue with Avatar initials - added `name` property for creating initials in circle - now initials are generated from `fullName`, if that is not available, then from `name`. If `name` is not available (which technically should not happen, since it is obligatory) then 'N/A' will appear in circle
- this should fix the issue with empty circles
- the problem is two-fold, however, because even though `name` should be obligatory property, it is not always being passed down from parent components in `ayon-frontend` repository, separate fixes are necessary to implement there ( i have created branch with same name there and will implement those changes)


<img width="838" alt="image" src="https://github.com/ynput/ayon-react-components/assets/16327908/f89cc14e-75a6-4844-9813-4603738de1a8">

