### PR TITLE
Fix: Fixed brackets for mixed tags

### DIFF
--- a/src/Dropdowns/TagsSelect/TagsSelect.tsx
+++ b/src/Dropdowns/TagsSelect/TagsSelect.tsx
@@ -110,7 +110,6 @@ export const TagsSelect = forwardRef<DropdownRef, TagsSelectProps>(
         align={align}
         style={styleDropdown}
         width={width}
-        
       />
     )
   },

--- a/src/Dropdowns/TagsSelect/TagsSelect.tsx
+++ b/src/Dropdowns/TagsSelect/TagsSelect.tsx
@@ -39,6 +39,7 @@ export const TagsSelect = forwardRef<DropdownRef, TagsSelectProps>(
       styleDropdown,
       width = 300,
       valueProps,
+      isMultiple,
       ...props
     },
     ref,
@@ -75,6 +76,7 @@ export const TagsSelect = forwardRef<DropdownRef, TagsSelectProps>(
             {...valueProps}
             tags={tags}
             editor={editor}
+            isMultiple={isMultiple}
           />
         )}
         itemTemplate={(tag, isActive, isSelected, i) => (
@@ -108,6 +110,7 @@ export const TagsSelect = forwardRef<DropdownRef, TagsSelectProps>(
         align={align}
         style={styleDropdown}
         width={width}
+        
       />
     )
   },


### PR DESCRIPTION
## Changelog description

- Brackets in tags did not appear when they had mixed value, turns out one property was not being properly passed down


https://github.com/ynput/ayon-react-components/assets/16327908/75992f09-3d52-42c4-b2e6-3f1b94305251

