### PR TITLE
Fix: entity card image not showing

### DIFF
--- a/src/EntityCard/EntityCard.styled.ts
+++ b/src/EntityCard/EntityCard.styled.ts
@@ -322,8 +322,7 @@ export const Image = styled.img`
 
   /* loading transition */
   opacity: 1;
-  transition: opacity 300ms;
-  transition-delay: 100ms;
+  transition: opacity 200ms;
 
   &.loading {
     opacity: 0;
@@ -405,8 +404,8 @@ export const NoImageIcon = styled(Icon)`
 
   /* loading transition */
   opacity: 1;
-  transition: opacity 300ms;
-  transition-delay: 300ms;
+  transition: opacity 200ms;
+  transition-delay: 100ms;
 
   &.loading {
     opacity: 0;

--- a/src/EntityCard/EntityCard.tsx
+++ b/src/EntityCard/EntityCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useState } from 'react'
+import { forwardRef, useState } from 'react'
 import { Icon, IconType } from '../Icon'
 import * as Styled from './EntityCard.styled'
 import { User, UserImagesStacked } from '../User/UserImagesStacked'
@@ -92,14 +92,13 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
     const [isImageError, setIsImageError] = useState(!imageUrl)
     const [isImageLoading, setIsImageLoading] = useState(!!imageUrl)
 
-    // reset image loading state
-    useEffect(() => {
-      setIsImageError(!imageUrl)
-      setIsImageLoading(!!imageUrl)
-    }, [imageUrl])
-
     const handleImageError = () => {
       setIsImageError(true)
+      setIsImageLoading(false)
+    }
+
+    const handleImageLoad = () => {
+      console.log('image load')
       setIsImageLoading(false)
     }
 
@@ -160,7 +159,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             <Styled.Image
               src={imageUrl}
               onError={handleImageError}
-              onLoad={() => setIsImageLoading(false)}
+              onLoad={handleImageLoad}
               className={clsx({ loading: isImageLoading })}
             />
           )}


### PR DESCRIPTION
- Fix: image/icon was not showing when component was unmounting and then remounting.
- Fix: reduce the transition time for fading in the image.