### PR TITLE
enhancement: added switch for showing/hiding characters in password + textinput

### DIFF
--- a/src/Inputs/InputNumber/InputNumber.tsx
+++ b/src/Inputs/InputNumber/InputNumber.tsx
@@ -1,5 +1,5 @@
 import { InputHTMLAttributes, forwardRef } from 'react'
-import StyledInput from '../styles'
+import { StyledInput } from '../styles'
 
 export const InputNumber = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
   (props, ref) => <StyledInput type="number" ref={ref} {...props} />,

--- a/src/Inputs/InputPassword/InputPassword.stories.tsx
+++ b/src/Inputs/InputPassword/InputPassword.stories.tsx
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof InputPassword>
 export const Default: Story = {
   args: {
     value: 'Hello World',
-    canToggle: true,
+    canRevealPassword: true,
     placeholder: 'Enter your password',
     disabled: false,
     onChange: () => console.log('Password Changed'),

--- a/src/Inputs/InputPassword/InputPassword.stories.tsx
+++ b/src/Inputs/InputPassword/InputPassword.stories.tsx
@@ -12,6 +12,7 @@ type Story = StoryObj<typeof InputPassword>
 
 export const Default: Story = {
   args: {
+    canToggle: true,
     placeholder: 'Enter your password',
     disabled: false,
     onChange: () => console.log('Password Changed'),

--- a/src/Inputs/InputPassword/InputPassword.stories.tsx
+++ b/src/Inputs/InputPassword/InputPassword.stories.tsx
@@ -12,6 +12,7 @@ type Story = StoryObj<typeof InputPassword>
 
 export const Default: Story = {
   args: {
+    value: 'Hello World',
     canToggle: true,
     placeholder: 'Enter your password',
     disabled: false,

--- a/src/Inputs/InputPassword/InputPassword.tsx
+++ b/src/Inputs/InputPassword/InputPassword.tsx
@@ -3,17 +3,17 @@ import { StyledInput, StyledToggleInput } from '../styles'
 import { Icon } from '../../Icon'
 
 export interface PasswordInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  canToggle?: boolean;
+  canRevealPassword?: boolean;
 }
 
-export const InputPassword = forwardRef<HTMLInputElement, PasswordInputProps>(({ canToggle = true, ...props}, ref) => {
+export const InputPassword = forwardRef<HTMLInputElement, PasswordInputProps>(({ canRevealPassword = true, ...props}, ref) => {
 
     const [isVisible, setIsVisible] = useState(false)
     const resolveIcon = isVisible ? 'visibility_off' : 'visibility'
     const handleVisible = () => setIsVisible(!isVisible)
     
     return (
-      !!canToggle ?
+      !!canRevealPassword ?
       <StyledToggleInput>
         <StyledInput type={isVisible ? '' : 'password'} ref={ref} {...props} />
         <Icon className="eyeIcon" onClick={handleVisible} icon={resolveIcon}/>

--- a/src/Inputs/InputPassword/InputPassword.tsx
+++ b/src/Inputs/InputPassword/InputPassword.tsx
@@ -6,7 +6,7 @@ export interface PasswordInputProps extends InputHTMLAttributes<HTMLInputElement
   canToggle?: boolean;
 }
 
-export const InputPassword = forwardRef<HTMLInputElement, PasswordInputProps>(({ canToggle, ...props}, ref) => {
+export const InputPassword = forwardRef<HTMLInputElement, PasswordInputProps>(({ canToggle = true, ...props}, ref) => {
 
     const [isVisible, setIsVisible] = useState(false)
     const resolveIcon = isVisible ? 'visibility_off' : 'visibility'

--- a/src/Inputs/InputPassword/InputPassword.tsx
+++ b/src/Inputs/InputPassword/InputPassword.tsx
@@ -1,7 +1,26 @@
-import { InputHTMLAttributes, forwardRef } from 'react'
-import StyledInput from '../styles'
+import { InputHTMLAttributes, forwardRef, useState } from 'react'
+import { StyledInput, StyledToggleInput } from '../styles'
+import { Icon } from '../../Icon'
 
-export const InputPassword = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
-  (props, ref) => <StyledInput type="password" ref={ref} {...props} />,
+export interface PasswordInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  canToggle?: boolean;
+}
+
+export const InputPassword = forwardRef<HTMLInputElement, PasswordInputProps>(({ canToggle, ...props}, ref) => {
+
+    const [isVisible, setIsVisible] = useState(false)
+    const resolveIcon = isVisible ? 'visibility_off' : 'visibility'
+    const handleVisible = () => setIsVisible(!isVisible)
+    
+    return (
+      !!canToggle ?
+      <StyledToggleInput>
+        <StyledInput type={isVisible ? '' : 'password'} ref={ref} {...props} />
+        <Icon className="eyeIcon" onClick={handleVisible} icon={resolveIcon}/>
+      </StyledToggleInput>
+      :
+      <StyledInput type={'password'} ref={ref} {...props} />
+    )
+  }
 )
 InputPassword.displayName = 'InputPassword'

--- a/src/Inputs/InputText/InputText.stories.tsx
+++ b/src/Inputs/InputText/InputText.stories.tsx
@@ -13,7 +13,6 @@ type Story = StoryObj<typeof InputText>
 export const Default: Story = {
   args: {
     value: 'Hello World',
-    canToggle: false,
     placeholder: 'Enter text here...',
     disabled: false,
     onChange: () => console.log('Text Changed'),

--- a/src/Inputs/InputText/InputText.stories.tsx
+++ b/src/Inputs/InputText/InputText.stories.tsx
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof InputText>
 export const Default: Story = {
   args: {
     value: 'Hello World',
-    canToggle: true,
+    canToggle: false,
     placeholder: 'Enter text here...',
     disabled: false,
     onChange: () => console.log('Text Changed'),

--- a/src/Inputs/InputText/InputText.stories.tsx
+++ b/src/Inputs/InputText/InputText.stories.tsx
@@ -13,6 +13,7 @@ type Story = StoryObj<typeof InputText>
 export const Default: Story = {
   args: {
     value: 'Hello World',
+    canToggle: true,
     placeholder: 'Enter text here...',
     disabled: false,
     onChange: () => console.log('Text Changed'),

--- a/src/Inputs/InputText/InputText.tsx
+++ b/src/Inputs/InputText/InputText.tsx
@@ -1,7 +1,26 @@
-import { InputHTMLAttributes, forwardRef } from 'react'
-import StyledInput from '../styles'
+import { InputHTMLAttributes, forwardRef, useState } from 'react'
+import { StyledInput, StyledToggleInput } from '../styles'
+import { Icon } from '../../Icon';
 
-export const InputText = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
-  (props, ref) => <StyledInput type="text" ref={ref} {...props} />,
+export interface InputTextProps extends InputHTMLAttributes<HTMLInputElement> {
+  canToggle?: boolean;
+}
+
+export const InputText = forwardRef<HTMLInputElement, InputTextProps>(({ canToggle, ...props}, ref) => {
+
+  const [isVisible, setIsVisible] = useState(false)
+  const resolveIcon = isVisible ? 'visibility_off' : 'visibility'
+  const handleVisible = () => setIsVisible(!isVisible)
+  
+  return (
+    !!canToggle ?
+    <StyledToggleInput>
+      <StyledInput $isHidden={!isVisible} type="text" ref={ref} {...props} />
+      <Icon className="eyeIcon" onClick={handleVisible} icon={resolveIcon}/>
+    </StyledToggleInput>
+    :
+    <StyledInput type="text" ref={ref} {...props} />
+  )
+}
 )
 InputText.displayName = 'InputText'

--- a/src/Inputs/InputText/InputText.tsx
+++ b/src/Inputs/InputText/InputText.tsx
@@ -1,26 +1,7 @@
-import { InputHTMLAttributes, forwardRef, useState } from 'react'
-import { StyledInput, StyledToggleInput } from '../styles'
-import { Icon } from '../../Icon';
+import { InputHTMLAttributes, forwardRef } from 'react'
+import { StyledInput } from '../styles'
 
-export interface InputTextProps extends InputHTMLAttributes<HTMLInputElement> {
-  canToggle?: boolean;
-}
-
-export const InputText = forwardRef<HTMLInputElement, InputTextProps>(({ canToggle, ...props}, ref) => {
-
-  const [isVisible, setIsVisible] = useState(false)
-  const resolveIcon = isVisible ? 'visibility_off' : 'visibility'
-  const handleVisible = () => setIsVisible(!isVisible)
-  
-  return (
-    !!canToggle ?
-    <StyledToggleInput>
-      <StyledInput $isHidden={!isVisible} type="text" ref={ref} {...props} />
-      <Icon className="eyeIcon" onClick={handleVisible} icon={resolveIcon}/>
-    </StyledToggleInput>
-    :
-    <StyledInput type="text" ref={ref} {...props} />
-  )
-}
+export const InputText = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  (props, ref) => <StyledInput type="text" ref={ref} {...props} />,
 )
 InputText.displayName = 'InputText'

--- a/src/Inputs/styles.tsx
+++ b/src/Inputs/styles.tsx
@@ -39,16 +39,22 @@ export const StyledInput = styled.input<{ $isHidden?: boolean }>`
 
 export const StyledToggleInput = styled.div`
   display: flex;
-
+  
   > input {
     width: 180px;
     padding-right: 32px;
   }
+
   > .eyeIcon {
     position: relative;
     display: flex;
     align-items: center;
     right: 28px;
     cursor: pointer;
+    user-select: none;
+    color: var(--md-sys-color-outline);
+    &:hover { 
+      color: var(--md-sys-color-on-surface);
+    }
   }
 `

--- a/src/Inputs/styles.tsx
+++ b/src/Inputs/styles.tsx
@@ -1,6 +1,6 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-const StyledInput = styled.input`
+export const StyledInput = styled.input<{ $isHidden?: boolean }>`
   color: var(--md-sys-color-on-surface);
   border: 1px solid var(--md-sys-color-outline-variant);
   background-color: var(--md-sys-color-surface-container-low);
@@ -8,6 +8,9 @@ const StyledInput = styled.input`
   min-height: var(--base-input-size);
   max-height: var(--base-input-size);
   padding: 0 8px;
+
+  // Password-like conversion of characters to full circles for input type="text"
+  ${({ $isHidden }) => $isHidden && `-webkit-text-security: disc;`}
 
   &:focus {
     outline: 1px solid var(--md-sys-color-primary);
@@ -34,4 +37,18 @@ const StyledInput = styled.input`
   }
 `
 
-export default StyledInput
+export const StyledToggleInput = styled.div`
+  display: flex;
+
+  > input {
+    width: 180px;
+    padding-right: 32px;
+  }
+  > .eyeIcon {
+    position: relative;
+    display: flex;
+    align-items: center;
+    right: 28px;
+    cursor: pointer;
+  }
+`


### PR DESCRIPTION
## Changelog descripton

This is solution to issue reported originally in ayon-frontend repository
https://github.com/ynput/ayon-frontend/issues/332

- I have updated input component so that there is switch for hiding characters.
- Originally, this was required only for input type="password", however, some of the required places have input type="text"
- Rather than changing type of  from text to password, I have added CSS property for text input that can hide characters
- Hiding characters for input type="text" may not be working for IE - https://caniuse.com/?search=text-security

Result:
- Now hiding works for both types (text and password), logic is slightly different though
- Hiding is optional (both text and password input can be with or without toggling icon and logic)

Password:
https://github.com/ynput/ayon-react-components/assets/16327908/6ac79391-2621-41c3-b08c-2c0a19f2d58f

TextInput:
https://github.com/ynput/ayon-react-components/assets/16327908/2861a469-530c-4876-96f6-fd3837e3072a




