### PR TITLE
fix: hide close button by default

### DIFF
--- a/src/Overlay/Dialog/Dialog.stories.tsx
+++ b/src/Overlay/Dialog/Dialog.stories.tsx
@@ -40,7 +40,6 @@ const Template = (args: Story['args']) => {
       <Dialog
         header={<HeaderContent />}
         children={<BodyContent />}
-        footer={<FooterContent />}
         isOpen={openModal}
         onClose={() => setOpenModal(false)}
         closeProps={closeProps}
@@ -56,6 +55,14 @@ const Template = (args: Story['args']) => {
 export const Default: Story = {
   render: Template,
 }
+
+export const Footer: Story = {
+  render: Template,
+  args: {
+    footer: <FooterContent />,
+  },
+}
+
 export const DialogVariant: Story = {
   render: Template,
   args: {

--- a/src/Overlay/Dialog/Dialog.stories.tsx
+++ b/src/Overlay/Dialog/Dialog.stories.tsx
@@ -12,46 +12,53 @@ export default meta
 
 type Story = StoryObj<typeof Dialog>
 
-
 const HeaderContent = () => <div>This is title of dialog</div>
 
 const BodyContent = () => (
   <>
-    <div>Are you sure you want to permanently delete this folder and all its associated tasks, products, versions, representations, and workfiles?</div>
+    <div>
+      Are you sure you want to permanently delete this folder and all its associated tasks,
+      products, versions, representations, and workfiles?
+    </div>
   </>
 )
 
 const FooterContent = () => <span>Ynput is awesome. Copyright ©2024 Ynput</span>
 
 const closeProps = {
-  label: 'Close'
+  label: 'Close',
 }
 
-const Template = () => {
-
+const Template = (args: Story['args']) => {
   const [openModal, setOpenModal] = useState(false)
-  
+
   return (
     <>
       <Button onClick={() => setOpenModal(!openModal)} icon="open_in_full">
         Show Modal
       </Button>
-      <Dialog 
-        header={<HeaderContent/>}
+      <Dialog
+        header={<HeaderContent />}
         children={<BodyContent />}
         footer={<FooterContent />}
         isOpen={openModal}
         onClose={() => setOpenModal(false)}
         closeProps={closeProps}
         hideCancelButton={false}
-        size='full'
-        variant='dialog'
+        size="full"
         onShow={() => console.log('test123')}
+        {...args}
       />
     </>
   )
 }
 
 export const Default: Story = {
-  render: () => Template(),
+  render: Template,
+}
+export const DialogVariant: Story = {
+  render: Template,
+  args: {
+    variant: 'dialog',
+  },
 }

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -88,16 +88,17 @@ export const BaseDialogEdge = styled.div`
   gap: 8px;
 `
 
-export const Header = styled(BaseDialogEdge)<{ hideCancelButton?: boolean }>`
+export const Header = styled(BaseDialogEdge)`
   position: relative;
   display: flex;
   flex-direction: column;
   padding: 16px;
-  ${({ hideCancelButton }) =>
-    !hideCancelButton &&
-    css`
-      padding-right: 48px;
-    `}
+  padding-right: 48px;
+
+  &.hideCancelButton {
+    padding-right: 16px;
+  }
+
   ${titleLarge}
   & > * {
     ${titleLarge}

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -78,8 +78,7 @@ export const Dialog = styled.dialog<{ $size?: string }>`
 export const Close = styled(Button)`
   position: absolute;
   right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 8px;
 `
 
 export const BaseDialogEdge = styled.div`

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -2,7 +2,6 @@ import styled, { css, keyframes } from 'styled-components'
 import { Button } from '../../Button'
 import { titleLarge } from '../../theme'
 
-
 const fadeInAnimation = keyframes`
   0% {
     opacity: 0.3;
@@ -14,56 +13,66 @@ const fadeInAnimation = keyframes`
   }
 `
 
-const widthSizes  = {
+const widthSizes = {
   sm: '400px',
   md: '600px',
   lg: '800px',
   full: '85%',
-};
+}
 
-const heightSizes  = {
+const heightSizes = {
   sm: '300px',
   md: '400px',
   lg: '500px',
   full: '85%',
-};
+}
 
-const getWidthSize = (size: string) => size ? widthSizes[size as keyof typeof widthSizes] : widthSizes.sm;
-const getHeightSize = (size: string) => size ? heightSizes[size as keyof typeof heightSizes] : heightSizes.sm;
-
+const getWidthSize = (size: string) =>
+  size ? widthSizes[size as keyof typeof widthSizes] : widthSizes.sm
+const getHeightSize = (size: string) =>
+  size ? heightSizes[size as keyof typeof heightSizes] : heightSizes.sm
 
 export const Dialog = styled.dialog<{ $size?: string }>`
-    background-color: var(--md-sys-color-surface-container);
-    border: none;
-    border-radius: var(--border-radius-m);
-    flex-direction: column;
-    gap: 16px;
-    padding: 0;
-    min-width: 200px;
-    min-height: 100px;
-    max-width: 85%;
-    width: ${({ $size }) => $size ? css` ${getWidthSize($size)}` : '200px'};
-    max-Height: ${({ $size }) => $size ? css` ${getHeightSize($size)}` : '100px' };
+  background-color: var(--md-sys-color-surface-container);
+  border: none;
+  border-radius: var(--border-radius-m);
+  flex-direction: column;
+  padding: 0;
+  min-width: 200px;
+  min-height: 100px;
+  max-width: 85%;
+  width: ${({ $size }) =>
+    $size
+      ? css`
+          ${getWidthSize($size)}
+        `
+      : '200px'};
+  max-height: ${({ $size }) =>
+    $size
+      ? css`
+          ${getHeightSize($size)}
+        `
+      : '100px'};
 
-    /* Backdrop property affects inactive area around modal */
-    &::backdrop {
-      background-color: rgba(0, 0, 0, 0.3);
-    }
+  /* Backdrop property affects inactive area around modal */
+  &::backdrop {
+    background-color: rgba(0, 0, 0, 0.3);
+  }
 
-    /* Styles for dialogs that carry modal behavior */
-    &:modal {
-    }
+  /* Styles for dialogs that carry modal behavior */
+  &:modal {
+  }
 
-    /* Styles for dialogs that carry non-modal behavior */
-    &:not(:modal) {
-    }
+  /* Styles for dialogs that carry non-modal behavior */
+  &:not(:modal) {
+  }
 
-    &[open] {
-      display: flex;
-      animation: ${fadeInAnimation} 150ms ease-in-out forwards, ${fadeInAnimation} 150ms ease-in-out backwards;
-      animation-fill-mode: both;
-    }
-
+  &[open] {
+    display: flex;
+    animation: ${fadeInAnimation} 150ms ease-in-out forwards,
+      ${fadeInAnimation} 150ms ease-in-out backwards;
+    animation-fill-mode: both;
+  }
 `
 
 export const Close = styled(Button)`
@@ -79,15 +88,18 @@ export const BaseDialogEdge = styled.div`
   gap: 8px;
 `
 
-
 export const Header = styled(BaseDialogEdge)<{ hideCancelButton?: boolean }>`
   position: relative;
   display: flex;
   flex-direction: column;
   padding: 16px;
-  ${({ hideCancelButton }) => !hideCancelButton && css`padding-right: 32px;`}
+  ${({ hideCancelButton }) =>
+    !hideCancelButton &&
+    css`
+      padding-right: 32px;
+    `}
   ${titleLarge}
-  & > * { 
+  & > * {
     ${titleLarge}
   }
 `
@@ -105,4 +117,3 @@ export const Body = styled.div`
   overflow: auto;
   flex-grow: 1;
 `
-

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -56,7 +56,7 @@ export const Dialog = styled.dialog<{ $size?: string }>`
 
   /* Backdrop property affects inactive area around modal */
   &::backdrop {
-    background-color: rgba(0, 0, 0, 0.3);
+    background-color: rgba(0, 0, 0, 0.5);
   }
 
   /* Styles for dialogs that carry modal behavior */

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -96,7 +96,7 @@ export const Header = styled(BaseDialogEdge)<{ hideCancelButton?: boolean }>`
   ${({ hideCancelButton }) =>
     !hideCancelButton &&
     css`
-      padding-right: 32px;
+      padding-right: 48px;
     `}
   ${titleLarge}
   & > * {

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -1,6 +1,6 @@
 import styled, { css, keyframes } from 'styled-components'
 import { Button } from '../../Button'
-import { titleLarge } from '../../theme'
+import { titleMedium } from '../../theme'
 
 const fadeInAnimation = keyframes`
   0% {
@@ -99,9 +99,9 @@ export const Header = styled(BaseDialogEdge)`
     padding-right: 16px;
   }
 
-  ${titleLarge}
+  ${titleMedium}
   & > * {
-    ${titleLarge}
+    ${titleMedium}
   }
 `
 

--- a/src/Overlay/Dialog/Dialog.tsx
+++ b/src/Overlay/Dialog/Dialog.tsx
@@ -9,6 +9,7 @@ export interface DialogProps extends Omit<React.HTMLAttributes<HTMLDialogElement
   footer?: React.ReactNode
   closeProps?: ButtonProps
   hideCancelButton?: boolean
+  showCloseButton?: boolean
   isOpen: boolean
   onClose?: () => void
   onShow?: () => void
@@ -31,6 +32,7 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>((props) => {
     header,
     footer,
     hideCancelButton = false,
+    showCloseButton = false,
     closeProps,
     isOpen,
     onClose,
@@ -38,7 +40,7 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>((props) => {
     classNames,
     size,
     onShow,
-    variant = 'modal'
+    variant = 'modal',
   } = props
 
   const [isModalOpen, setModalOpen] = useState(isOpen)
@@ -53,11 +55,11 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>((props) => {
   useEffect(() => {
     const modalElement = modalRef.current
     if (!modalElement) return
-    const showDialog =  variant === 'dialog' && modalElement.show()
-    const showModal =  variant === 'modal' && modalElement.showModal()
+    const showDialog = variant === 'dialog' && modalElement.show()
+    const showModal = variant === 'modal' && modalElement.showModal()
     const showAll = () => {
-        showDialog || showModal
-        onShow && onShow()
+      showDialog || showModal
+      onShow && onShow()
     }
     isModalOpen ? showAll() : modalElement.close()
   }, [isModalOpen])
@@ -76,26 +78,30 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>((props) => {
       {...props}
     >
       <Styled.Header className={clsx('header', classNames?.header)}>
-          {header ? header : ''}
-          {hideCancelButton ? null : (
-            <Styled.Close 
-              className={clsx('cancelButton', classNames?.cancelButton)}
-              icon="close"
-              variant="text"
-              autoFocus
-              onClick={handleCloseModal}
-            /> )}
+        {header ? header : ''}
+        {hideCancelButton ? null : (
+          <Styled.Close
+            className={clsx('cancelButton', classNames?.cancelButton)}
+            icon="close"
+            variant="text"
+            autoFocus
+            onClick={handleCloseModal}
+          />
+        )}
       </Styled.Header>
       {children && <Styled.Body className={clsx('body', classNames?.body)}>{children}</Styled.Body>}
       <Styled.Footer className={clsx('footer', classNames?.footer)}>
-          { footer && footer } 
+        {showCloseButton && (
           <Button
-            label={!!closeProps?.label ? closeProps.label : 'Cancel'}
+            label={!!closeProps?.label ? closeProps.label : 'Close'}
             className={clsx('closeButton', classNames?.closeButton)}
             variant="text"
             onClick={handleCloseModal}
             {...closeProps}
           />
+        )}
+        {footer && footer}
       </Styled.Footer>
     </Styled.Dialog>
-)})
+  )
+})

--- a/src/Overlay/Dialog/Dialog.tsx
+++ b/src/Overlay/Dialog/Dialog.tsx
@@ -90,18 +90,20 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>((props) => {
         )}
       </Styled.Header>
       {children && <Styled.Body className={clsx('body', classNames?.body)}>{children}</Styled.Body>}
-      <Styled.Footer className={clsx('footer', classNames?.footer)}>
-        {showCloseButton && (
-          <Button
-            label={!!closeProps?.label ? closeProps.label : 'Close'}
-            className={clsx('closeButton', classNames?.closeButton)}
-            variant="text"
-            onClick={handleCloseModal}
-            {...closeProps}
-          />
-        )}
-        {footer && footer}
-      </Styled.Footer>
+      {(footer || showCloseButton) && (
+        <Styled.Footer className={clsx('footer', classNames?.footer)}>
+          {showCloseButton && (
+            <Button
+              label={!!closeProps?.label ? closeProps.label : 'Close'}
+              className={clsx('closeButton', classNames?.closeButton)}
+              variant="text"
+              onClick={handleCloseModal}
+              {...closeProps}
+            />
+          )}
+          {footer && footer}
+        </Styled.Footer>
+      )}
     </Styled.Dialog>
   )
 })

--- a/src/Overlay/Dialog/Dialog.tsx
+++ b/src/Overlay/Dialog/Dialog.tsx
@@ -77,7 +77,7 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>((props) => {
       className={clsx('modal', className)}
       {...props}
     >
-      <Styled.Header className={clsx('header', classNames?.header)}>
+      <Styled.Header className={clsx('header', { hideCancelButton }, classNames?.header)}>
         {header ? header : ''}
         {hideCancelButton ? null : (
           <Styled.Close


### PR DESCRIPTION
Currently there are two buttons that do the same thing, the top right close icon and the bottom footer cancel button.

I think the cancel button can be hidden by default unless specified, the majority of cases don't require it.