### PR TITLE
Dialog: used div instead of dialog tag

### DIFF
--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -584,6 +584,10 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
           // focus back on button
           valueRef.current?.focus()
         }
+
+        // stop default tab behavior
+        e.preventDefault()
+        e.stopPropagation()
         handleClose()
       }
     }

--- a/src/Overlay/Dialog/Dialog.stories.tsx
+++ b/src/Overlay/Dialog/Dialog.stories.tsx
@@ -38,15 +38,15 @@ const Template = (args: Story['args']) => {
         Show Modal
       </Button>
       <Dialog
+        {...args}
         header={<HeaderContent />}
         children={<BodyContent />}
         isOpen={openModal}
         onClose={() => setOpenModal(false)}
+        onShow={() => console.log('onShow')}
         closeProps={closeProps}
         hideCancelButton={false}
-        size="full"
-        onShow={() => console.log('test123')}
-        {...args}
+        size="lg"
       />
     </>
   )
@@ -65,7 +65,4 @@ export const Footer: Story = {
 
 export const DialogVariant: Story = {
   render: Template,
-  args: {
-    variant: 'dialog',
-  },
 }

--- a/src/Overlay/Dialog/Dialog.stories.tsx
+++ b/src/Overlay/Dialog/Dialog.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Dialog } from '.'
 import { useState } from 'react'
 import { Button } from '../../Button'
+import { InputColor } from '../../Inputs/InputColor'
+import { Dropdown } from '../../Dropdowns/Dropdown'
 
 const meta: Meta<typeof Dialog> = {
   component: Dialog,
@@ -29,6 +31,15 @@ const closeProps = {
   label: 'Close',
 }
 
+const defaultArgs: Story['args'] = {
+  header: <HeaderContent />,
+  children: <BodyContent />,
+  size: 'full',
+  onShow: () => console.log('onShow'),
+  closeProps: closeProps,
+  hideCancelButton: true,
+}
+
 const Template = (args: Story['args']) => {
   const [openModal, setOpenModal] = useState(false)
 
@@ -37,17 +48,7 @@ const Template = (args: Story['args']) => {
       <Button onClick={() => setOpenModal(!openModal)} icon="open_in_full">
         Show Modal
       </Button>
-      <Dialog
-        {...args}
-        header={<HeaderContent />}
-        children={<BodyContent />}
-        isOpen={openModal}
-        onClose={() => setOpenModal(false)}
-        onShow={() => console.log('onShow')}
-        closeProps={closeProps}
-        hideCancelButton={false}
-        size="lg"
-      />
+      <Dialog {...defaultArgs} {...args} isOpen={openModal} onClose={() => setOpenModal(false)} />
     </>
   )
 }
@@ -62,7 +63,26 @@ export const Footer: Story = {
     footer: <FooterContent />,
   },
 }
-
-export const DialogVariant: Story = {
+export const DropdownInput: Story = {
   render: Template,
+  args: {
+    children: (
+      <Dropdown
+        options={[
+          { value: 'option1' },
+          {
+            value: 'option2',
+          },
+        ]}
+        value={['option1']}
+      />
+    ),
+  },
+}
+
+export const ColorPicker: Story = {
+  render: Template,
+  args: {
+    children: <InputColor value={'#fff'} onChange={() => console.log('onChange')} />,
+  },
 }

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -74,6 +74,12 @@ export const Close = styled(Button)`
   position: absolute;
   right: 8px;
   top: 8px;
+
+  &.isHidden {
+    user-select: none;
+    opacity: 0;
+    pointer-events: none;
+  }
 `
 
 export const BaseDialogEdge = styled.div`

--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -5,11 +5,11 @@ import { titleMedium } from '../../theme'
 const fadeInAnimation = keyframes`
   0% {
     opacity: 0.3;
-    transform: scale(0.8);
+    scale: 0.8;
   }
   100% {
     opacity: 1;
-    transform: scale(1);
+    scale: 1;
   }
 `
 
@@ -32,15 +32,13 @@ const getWidthSize = (size: string) =>
 const getHeightSize = (size: string) =>
   size ? heightSizes[size as keyof typeof heightSizes] : heightSizes.sm
 
-export const Dialog = styled.dialog<{ $size?: string }>`
+export const Dialog = styled.div<{ $size?: string }>`
   background-color: var(--md-sys-color-surface-container);
   border: none;
   border-radius: var(--border-radius-m);
   flex-direction: column;
   padding: 0;
-  min-width: 200px;
-  min-height: 100px;
-  max-width: 85%;
+
   width: ${({ $size }) =>
     $size
       ? css`
@@ -54,25 +52,22 @@ export const Dialog = styled.dialog<{ $size?: string }>`
         `
       : '100px'};
 
-  /* Backdrop property affects inactive area around modal */
-  &::backdrop {
-    background-color: rgba(0, 0, 0, 0.5);
-  }
+  position: fixed;
 
-  /* Styles for dialogs that carry modal behavior */
-  &:modal {
-  }
+  min-width: 200px;
+  min-height: 100px;
+  max-width: 85%;
 
-  /* Styles for dialogs that carry non-modal behavior */
-  &:not(:modal) {
-  }
+  left: 50%;
+  top: 50%;
+  translate: -50% -50%;
 
-  &[open] {
-    display: flex;
-    animation: ${fadeInAnimation} 150ms ease-in-out forwards,
-      ${fadeInAnimation} 150ms ease-in-out backwards;
-    animation-fill-mode: both;
-  }
+  display: flex;
+  animation: ${fadeInAnimation} 150ms ease-in-out forwards,
+    ${fadeInAnimation} 150ms ease-in-out backwards;
+  animation-fill-mode: both;
+
+  z-index: 1000;
 `
 
 export const Close = styled(Button)`
@@ -116,4 +111,22 @@ export const Body = styled.div`
   flex-direction: column;
   overflow: auto;
   flex-grow: 1;
+`
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+
+
+  } to {
+    opacity: 1;
+  
+  }`
+
+export const Backdrop = styled.div`
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  inset: 0;
+  animation: ${fadeIn} 150ms ease-in-out forwards;
+  animation-fill-mode: both;
 `

--- a/src/Overlay/Dialog/Dialog.tsx
+++ b/src/Overlay/Dialog/Dialog.tsx
@@ -72,21 +72,25 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>((props, ref) => {
       <Styled.Dialog
         $size={size}
         ref={ref}
-        className={clsx('modal', className)}
+        className={clsx('dialog', className)}
         onKeyDown={handleKeyDown}
+        tabIndex={0}
         {...rest}
       >
         <Styled.Header className={clsx('header', { hideCancelButton }, classNames?.header)}>
           {header ? header : ''}
-          {hideCancelButton ? null : (
-            <Styled.Close
-              className={clsx('cancelButton', classNames?.cancelButton)}
-              icon="close"
-              variant="text"
-              autoFocus
-              onClick={handleCloseModal}
-            />
-          )}
+
+          <Styled.Close
+            className={clsx(
+              'cancelButton',
+              { isHidden: hideCancelButton },
+              classNames?.cancelButton,
+            )}
+            icon="close"
+            variant="text"
+            onClick={handleCloseModal}
+            autoFocus
+          />
         </Styled.Header>
         {children && (
           <Styled.Body className={clsx('body', classNames?.body)}>{children}</Styled.Body>


### PR DESCRIPTION
### Changelog Description

The `dialog` tag has caused all sorts of problems with little upsides. Let's use the `div` tag instead and build some of the default properties the `dialog` tag had.