### PR TITLE
fix: added z-index for backdrop in Dialog

### DIFF
--- a/src/Overlay/Dialog/Dialog.styled.ts
+++ b/src/Overlay/Dialog/Dialog.styled.ts
@@ -135,4 +135,5 @@ export const Backdrop = styled.div`
   inset: 0;
   animation: ${fadeIn} 150ms ease-in-out forwards;
   animation-fill-mode: both;
+  z-index: 999;
 `


### PR DESCRIPTION
## Changelog Desciption

Backdrop was not overlaying through all elements in ayon-frontend, I added z-index.

<img width="1254" alt="image" src="https://github.com/ynput/ayon-react-components/assets/16327908/a4dedf81-33cd-49bf-940b-b4ccb64f8c69">
