### PR TITLE
enhancement:  disableReorder prop replaced with sortbySelected (defau…

### DIFF
--- a/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
@@ -101,7 +101,7 @@ export const AssigneeSelect = forwardRef<DropdownRef, AssigneeSelectProps>(
         search
         searchFields={['fullName', 'name', 'email']}
         ref={ref}
-        sortBySelected
+        sortBySelected={sortBySelected}
         {...props}
       />
     )

--- a/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
@@ -16,6 +16,7 @@ export interface AssigneeSelectProps extends Omit<DropdownProps, 'onChange' | 'e
   align?: 'left' | 'right'
   isMultiple?: boolean
   placeholder?: string
+  sortBySelected?: boolean
   emptyIcon?: AssigneeFieldProps['emptyIcon']
   emptyMessage?: AssigneeFieldProps['emptyMessage']
   size?: AssigneeFieldProps['size']
@@ -39,6 +40,7 @@ export const AssigneeSelect = forwardRef<DropdownRef, AssigneeSelectProps>(
       emptyMessage: assigneeEmptyMessage,
       size,
       assigneeProps,
+      sortBySelected = true,
       onAssigneeFieldClick,
       ...props
     },
@@ -99,6 +101,7 @@ export const AssigneeSelect = forwardRef<DropdownRef, AssigneeSelectProps>(
         search
         searchFields={['fullName', 'name', 'email']}
         ref={ref}
+        sortBySelected
         {...props}
       />
     )

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -121,6 +121,23 @@ export const Multiple: Story = {
   render: Template,
 }
 
+export const MultipleSorted: Story = {
+  args: {
+    isMultiple: true,
+    value: [options[0].value, options[1].value],
+    widthExpand: true,
+    multiSelect: true,
+    minSelected: 2,
+    align: 'right',
+    onClear: () => console.log('clear'),
+    style: {
+      width: 'unset',
+    },
+    sortBySelected: true
+  },
+  render: Template,
+}
+
 // custom item and option renderers
 // TODO: fix this!
 export const CustomTemplates: Story = {

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -89,10 +89,10 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   nullPlaceholder?: string
   editable?: boolean
   maxHeight?: number
-  disableReorder?: boolean
   disabledValues?: (string | number)[]
   listInline?: boolean
   disableOpen?: boolean
+  sortBySelected?: boolean
 }
 
 export interface DropdownRef {
@@ -147,10 +147,10 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       nullPlaceholder,
       editable,
       maxHeight = 300,
-      disableReorder,
       disabledValues = [],
       listInline = false,
       disableOpen = false,
+      sortBySelected = false,
       ...props
     },
     ref,
@@ -287,7 +287,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
     // reorder options to put active at the top (if not disabled)
     options = useMemo(
       () =>
-        disableReorder || !value || !value.length
+        !sortBySelected || !value || !value.length
           ? options
           : [...options].sort((a, b) => value.indexOf(b[dataKey]) - value.indexOf(a[dataKey])),
       [value, options],

--- a/src/Dropdowns/TagsSelect/TagsSelect.tsx
+++ b/src/Dropdowns/TagsSelect/TagsSelect.tsx
@@ -110,6 +110,7 @@ export const TagsSelect = forwardRef<DropdownRef, TagsSelectProps>(
         align={align}
         style={styleDropdown}
         width={width}
+        sortBySelected
       />
     )
   },

--- a/src/Dropdowns/VersionSelect/VersionSelect.tsx
+++ b/src/Dropdowns/VersionSelect/VersionSelect.tsx
@@ -63,7 +63,6 @@ export const VersionSelect = forwardRef<DropdownRef, VersionSelectProps>(
         listStyle={{ ...props.listStyle }}
         itemStyle={{ ...props.itemStyle }}
         widthExpand
-        disableReorder
         disabledValues={disabledVersions}
         {...props}
       />


### PR DESCRIPTION
## Changelog description

- added prop `sortbySelected`, removed `disableReorder`
- default behaviour for Dropdown is now **without** sorting (unless `sortbySelected` set to `true`)
-  AsigneeSelect has sorting by default turned on (can be turned off via props if required)





https://github.com/ynput/ayon-react-components/assets/16327908/05baee16-dfaf-43d8-929b-8a9552a87e4c


close #68 