### PR TITLE
enhancement:  added no backdrop option for dialog

### DIFF
--- a/src/Overlay/Dialog/Dialog.stories.tsx
+++ b/src/Overlay/Dialog/Dialog.stories.tsx
@@ -86,3 +86,11 @@ export const ColorPicker: Story = {
     children: <InputColor value={'#fff'} onChange={() => console.log('onChange')} />,
   },
 }
+
+export const NoBackdrop: Story = {
+  render: Template,
+  args: {
+    isBackdrop: false,
+    hideCancelButton: false,
+  },
+}

--- a/src/Overlay/Dialog/Dialog.tsx
+++ b/src/Overlay/Dialog/Dialog.tsx
@@ -16,6 +16,7 @@ export interface DialogProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
   onShow?: () => void
   classNames?: ClassNames
   size?: 'sm' | 'md' | 'lg' | 'full'
+  isBackdrop?: boolean
 }
 
 type ClassNames = {
@@ -33,6 +34,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>((props, ref) => {
     footer,
     hideCancelButton = false,
     showCloseButton = false,
+    isBackdrop = true,
     closeProps,
     isOpen,
     onClose,
@@ -68,7 +70,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>((props, ref) => {
 
   return createPortal(
     <>
-      <Styled.Backdrop onClick={(e) => closeIfClickOutside(e)} />
+      {isBackdrop && <Styled.Backdrop onClick={(e) => closeIfClickOutside(e)} />}
       <Styled.Dialog
         $size={size}
         ref={ref}


### PR DESCRIPTION
## PR Checklist

-   [ ] Added switch for backdrop
-   [ ] relates to issue from ayon-frontend https://github.com/ynput/ayon-frontend/issues/334

## Description of changes

- for some instaces we migth need dialog with no backdrop
- currently for adding new teams https://github.com/ynput/ayon-frontend/issues/334

### Technical details

- added isBackdrop prop that is set to true by default

### Additional context

https://github.com/ynput/ayon-react-components/assets/16327908/bb9bf9e1-b3e1-43d6-accb-c682d055eb2f