### PR TITLE
chore(dialog): better scroll story

### DIFF
--- a/src/Overlay/Dialog/Dialog.stories.tsx
+++ b/src/Overlay/Dialog/Dialog.stories.tsx
@@ -92,16 +92,9 @@ export const Scroll: Story = {
   args: {
     children: (
       <>
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
-        <BodyContent />
+        {Array.from({ length: 20 }).map((_, i) => (
+          <BodyContent key={i} />
+        ))}
       </>
     ),
   },


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] Dialog is in the center of the screen.
-   [x] Clicking on backdrop closes dialog but clicking on dialog doesn't.
-   [x] Overflow content is not blurry.

## Description of changes

Uses flexbox to center the dialog instead of

```css
  position: fixed;
  left: 50%;
  top: 50%;
  transform: translate(-50%, -50%);
```

### Additional context

Also changed prop name `isBackdrop=true` to `hideBackdrop=false`
