### PR TITLE
Assignee Select: setting first assignee closes dropdown automatically

### DIFF
--- a/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
@@ -68,7 +68,7 @@ export const AssigneeField = forwardRef<HTMLDivElement, AssigneeFieldProps>(
       disabled,
       isMultiple,
       placeholder,
-      emptyIcon = 'add_circle',
+      emptyIcon = 'person_add',
       emptyMessage = '',
       size = 21,
       ...props

--- a/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
@@ -11,10 +11,12 @@ const FieldStyled = styled.div<{ disabled?: boolean; isMultiple?: boolean }>`
   user-select: none;
   display: flex;
   align-items: center;
-  height: 30px;
+  justify-content: center;
+  min-width: 32px;
   gap: 4px;
+  display: flex;
 
-  span:not(.user-image) {
+  .name {
     position: relative;
     top: 1px;
     white-space: nowrap;
@@ -95,7 +97,7 @@ export const AssigneeField = forwardRef<HTMLDivElement, AssigneeFieldProps>(
                   maxWidth: size,
                 }}
               />
-              {value.length < 2 && <span>{value[0]?.fullName}</span>}
+              {value.length < 2 && <span className="name">{value[0]?.fullName}</span>}
             </>
           ) : (
             <>

--- a/src/Dropdowns/AssigneeSelect/AssigneeSelect.stories.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeSelect.stories.tsx
@@ -48,13 +48,15 @@ const initArgs: AssigneeSelectProps = {
 const Template = (args: AssigneeSelectProps) => {
   const [value, setValue] = useState(args.value)
 
-  return <AssigneeSelect {...initArgs} {...args} onChange={(names) => setValue(names)} />
+  return (
+    <AssigneeSelect {...initArgs} {...args} value={value} onChange={(names) => setValue(names)} />
+  )
 }
 
 export const Default: Story = {
   render: Template,
   args: {
-    value: selectedUsers,
+    value: [],
   },
 }
 export const Custom: Story = {

--- a/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
@@ -97,7 +97,7 @@ export const AssigneeSelect = forwardRef<DropdownRef, AssigneeSelectProps>(
         onChange={(names) => onChange && onChange(names.map((name) => name.toString() as string))}
         widthExpand={widthExpand}
         align={align}
-        multiSelect
+        multiSelect={!!value.length}
         search
         searchFields={['fullName', 'name', 'email']}
         ref={ref}


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
- When no users are assigned the first selection of a user will close the dropdown straight away.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
This was surprisingly easy. All I needed to do was set `multiSelect={value.length}`. When there's no value it acts like a single select and when there's at least one user, it acts like a multiselect.

### Additional context

<!-- Add any other context or screenshots here. -->

https://github.com/ynput/ayon-react-components/assets/49156310/66eda9ce-31a7-459f-b500-6926c5d6ae2d


