### PR TITLE
Dropdown: Missing values warning

### DIFF
--- a/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import styled, { css } from 'styled-components'
 import { Icon, IconType } from '../../Icon'
 import { DropdownProps } from './Dropdown'
+import clsx from 'clsx'
 
 const DefaultValueStyled = styled.div`
   border: 1px solid var(--md-sys-color-outline-variant);
@@ -20,6 +21,14 @@ const DefaultValueStyled = styled.div`
 
   & > * {
     position: relative;
+  }
+
+  &.error {
+    border-color: var(--md-sys-color-error);
+  }
+
+  .icon.error {
+    color: var(--md-sys-color-error);
   }
 
   .icon.control {
@@ -69,6 +78,7 @@ export interface DefaultValueTemplateProps
   isOpen?: boolean
   className?: string
   childrenCustom?: React.ReactNode
+  error?: string
 }
 
 export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
@@ -88,11 +98,16 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
   isOpen,
   className,
   childrenCustom,
+  error,
 }) => {
   const noValue = !value?.length
 
   return (
-    <DefaultValueStyled style={style} $isOpen={!!isOpen} className={className}>
+    <DefaultValueStyled
+      style={style}
+      $isOpen={!!isOpen}
+      className={clsx('template-value', className, { error: !!error })}
+    >
       {noValue ? (
         <>
           <ContentStyled>
@@ -109,7 +124,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
               icon={'backspace'}
               onClick={() => onClearNull(null)}
               id={'backspace'}
-              className="control"
+              className="clear-null"
               tabIndex={0}
               data-tooltip={clearNullTooltip}
             />
@@ -119,7 +134,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
               icon={'close'}
               onClick={() => onClear([])}
               id={'clear'}
-              className="control"
+              className="clear"
               tabIndex={0}
               data-tooltip={clearTooltip}
             />
@@ -138,7 +153,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
               icon={'backspace'}
               onClick={() => onClearNull(null)}
               id={'backspace'}
-              className="control"
+              className="clear-null"
               tabIndex={0}
               data-tooltip={clearNullTooltip}
             />
@@ -148,7 +163,7 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
               icon={'close'}
               onClick={() => onClear([])}
               id="clear"
-              className="control"
+              className="clear"
               tabIndex={0}
               data-tooltip={clearTooltip}
             />
@@ -156,7 +171,11 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
         </>
       )}
       {childrenCustom}
-      <Icon icon={dropIcon} className="control" />
+      {!error ? (
+        <Icon icon={dropIcon} className="control" />
+      ) : (
+        <Icon icon="error" className="error" />
+      )}
     </DefaultValueStyled>
   )
 }

--- a/src/Dropdowns/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.stories.tsx
@@ -43,7 +43,7 @@ const Template = (args: DropdownProps) => {
   }
 
   return (
-    <Toolbar>
+    <Toolbar style={{ margin: 32 }}>
       <Dropdown
         {...args}
         value={value}
@@ -234,6 +234,18 @@ export const InvalidValue: Story = {
     value: null,
     multiSelect: true,
     nullPlaceholder: 'No value (custom placeholder)',
+  },
+  render: Template,
+}
+
+// when there are values but no options for those values
+export const MissingOptions: Story = {
+  args: {
+    value: ['pizza', 'burger', 'fries'],
+    options: [{ value: 'pizza' }, { value: 'burger' }],
+    multiSelect: true,
+    onSelectAll: undefined,
+    onClear: undefined,
   },
   render: Template,
 }

--- a/src/Dropdowns/Dropdown/Dropdown.styled.ts
+++ b/src/Dropdowns/Dropdown/Dropdown.styled.ts
@@ -104,6 +104,7 @@ export const dropdownMenuAnimation = () => keyframes`
 export const Container = styled.div<{
   $isOpen: boolean
   $message: string
+  $error: string
   $hidden: boolean
 }>`
   width: 100%;
@@ -123,25 +124,33 @@ export const Container = styled.div<{
   transform-origin: top center;
 
   /* show warning when changing multiple entities */
-  ${({ $isOpen, $message }) =>
+  ${({ $isOpen, $message, $error }) =>
     $isOpen &&
-    $message &&
+    ($error || $message) &&
     css`
       &::before {
-        content: '${$message}';
+        content: '${$error || $message}';
         top: 0;
-        translate: 0 -100%;
+        translate: 0 calc(-32px - 100%);
         position: absolute;
+
         background-color: var(--md-sys-color-surface-container-low);
-        border-radius: var(--border-radius-m) var(--border-radius-m) 0 0;
+        border-radius: var(--border-radius-m);
         z-index: 10;
         display: flex;
         align-items: center;
         padding: 4px 0;
         right: 0;
         left: 0;
-        border: 1px solid #383838;
+        border: 1px solid var(--md-sys-color-outline-variant);
         justify-content: center;
+
+        /* error styling */
+        ${$error &&
+        css`
+          color: var(--md-sys-color-on-error-container);
+          background-color: var(--md-sys-color-error-container);
+        `}
       }
     `}
 `
@@ -242,21 +251,30 @@ export const ListItem = styled.li<{
   }
 `
 
-export const DefaultItem = styled.span<{
-  $isSelected: boolean
-}>`
+export const DefaultItem = styled.span`
   display: flex;
   gap: 8px;
   align-items: center;
   height: 32px;
   padding: 0 8px;
 
-  ${({ $isSelected }) =>
-    $isSelected &&
-    css`
-      background-color: var(--md-sys-color-primary-container);
-      color: var(--md-sys-color-on-primary-container);
-    `}
+  &.selected {
+    background-color: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+
+    &:hover {
+      background-color: var(--md-sys-color-primary-container-hover);
+    }
+
+    &.error {
+      background-color: var(--md-sys-color-error-container);
+      color: var(--md-sys-color-on-error-container);
+
+      &:hover {
+        background-color: var(--md-sys-color-error-container-hover);
+      }
+    }
+  }
 `
 
 export const Search = styled.div`

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -101,6 +101,7 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   onSelectAll?: ((value: string[]) => void) | true
   selectAllKey?: string
   buttonProps?: Styled.ButtonType['defaultProps']
+  activateKeys?: string[]
 }
 
 export interface DropdownRef {
@@ -166,6 +167,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       onSelectAll,
       selectAllKey = '__all__',
       buttonProps,
+      activateKeys = ['Enter', 'Space', 'NumpadEnter', 'Tab'],
       ...props
     },
     ref,
@@ -628,12 +630,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       }
 
       // SUBMIT WITH ENTER
-      if (
-        e.code === 'Enter' ||
-        e.code === 'Space' ||
-        e.code === 'NumpadEnter' ||
-        e.code === 'Tab'
-      ) {
+      if (activateKeys.includes(e.code)) {
         // check we are not searching and pressing space
         if (e.code === 'Space' && search) return
 
@@ -641,7 +638,9 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
         if (e.code !== 'Tab') e.preventDefault()
 
         // if closed and pressing tab, ignore and focus next item (default)
-        if (!isOpen && e.code === 'Tab') return
+        if (e.code === 'Tab') {
+          if (!isOpen) return
+        }
 
         // open
         if (!isOpen) {
@@ -655,7 +654,8 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
         }
 
         if (multiSelect) {
-          if (selectedValue) return handleChange(selectedValue, activeIndex || 0)
+          if (selectedValue && e.code !== 'Tab')
+            return handleChange(selectedValue, activeIndex || 0)
 
           let selectedValues = [options[0][dataKey]]
           // if editable, split by comma
@@ -692,6 +692,9 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
           // focus back on button
           valueRef.current?.focus()
         }
+      } else if (e.code === 'Space') {
+        // prevent space from opening dropdown if it's not in activateKeys
+        e.preventDefault()
       }
 
       // CLOSE WITH ESC or TAB

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -66,6 +66,7 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   multiSelect?: boolean
   multiSelectClose?: boolean
   search?: boolean
+  searchOnNumber?: number
   disabled?: boolean
   valueIcon?: string
   emptyMessage?: string
@@ -137,6 +138,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       multiSelectClose = false,
       isMultiple,
       search,
+      searchOnNumber = 20,
       placeholder = 'Select an option...',
       emptyMessage,
       isChanged,
@@ -343,6 +345,11 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
     }, [editable, searchForm, options])
 
     const nonSearchedOptions = [...options]
+
+    // if number of options is over 20 and search is not false or null, turn search on
+    if (search === undefined && searchOnNumber !== undefined) {
+      search = options.length > searchOnNumber
+    }
 
     if ((search || editable) && searchForm) {
       // filter out search matches

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -254,6 +254,28 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       }
     }, [isOpen, valueRef, formRef, setMinWidth, setPos])
 
+    // scroll to first selected item
+    useEffect(() => {
+      if (!isOpen) return
+
+      // find first selected item
+      const firstSelectedElement = optionsRef.current?.querySelector('.selected')
+      if (!firstSelectedElement) return
+
+      // get parent li item
+      const parentLi = firstSelectedElement.parentElement as HTMLLIElement
+      if (!parentLi) return
+
+      // scroll to selected item
+      parentLi.scrollIntoView({ block: 'center' })
+
+      if (!parentLi.parentElement?.children) return
+      // find index of selected item
+      const index = Array.from(parentLi.parentElement?.children).indexOf(parentLi)
+
+      setActiveIndex(index)
+    }, [isOpen, setActiveIndex, optionsRef])
+
     // set initial selected from value
     useEffect(() => {
       setSelected(value)
@@ -861,6 +883,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
                         disabled: option.disabled || disabledValues.includes(option[dataKey]),
                         focused: usingKeyboard && activeIndex === i,
                       })}
+                      data-value={option[dataKey]}
                     >
                       {itemTemplate ? (
                         itemTemplate(


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
- Show a warning when there are values without options.
- New error message prop
- Automatically show the search after 20 options (can be disabled with `search=false` or `searchOnNumber=200`)
- Automatically scroll and focus first selected item.
- New prop `activateKeys` to define which keys can open the dropdown.

### Additional context

<!-- Add any other context or screenshots here. -->
![image](https://github.com/user-attachments/assets/ffca3019-f27e-439f-898c-15c8615870df)

