### PR TITLE
Entity card fixes

### DIFF
--- a/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeField.tsx
@@ -63,7 +63,7 @@ const FieldStyled = styled.div<{
 export interface AssigneeFieldProps extends React.HTMLAttributes<HTMLDivElement> {
   users: {
     name: string
-    fullName?: string
+    fullName?: string | null
     avatarUrl?: string
   }[]
   value?: (string | number)[]

--- a/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
+++ b/src/Dropdowns/AssigneeSelect/AssigneeSelect.tsx
@@ -6,7 +6,7 @@ export interface AssigneeSelectProps extends Omit<DropdownProps, 'onChange' | 'e
   value: string[]
   options: {
     name: string
-    fullName?: string
+    fullName?: string | null
     avatarUrl?: string
   }[]
   readOnly?: boolean

--- a/src/EntityCard/EntityCard.stories.tsx
+++ b/src/EntityCard/EntityCard.stories.tsx
@@ -32,20 +32,6 @@ const randomUsers = allUsers
 
 const randomPriority = priorities[Math.floor(Math.random() * priorities.length)]
 
-const initData: DataProps = {
-  header: 'ep103sq002',
-  path: 'ep103',
-  project: 'com',
-  title: 'Lighting',
-  titleIcon: 'lightbulb',
-  imageIcon: 'lightbulb',
-  isPlayable: true,
-  users: randomUsers,
-  status: randomStatus,
-  priority: randomPriority,
-  imageUrl: Math.random() > 0.5 ? getRandomImage() : undefined,
-}
-
 type TemplateProps = DataProps
 
 const Template = ({ onActivate, ...props }: TemplateProps) => {
@@ -162,6 +148,22 @@ const StatusTemplate = (props: TemplateProps) => {
       </StyledCell>
     </StatusWrapper>
   )
+}
+
+const initData: DataProps = {
+  header: 'ep103sq002',
+  path: 'ep103',
+  project: 'com',
+  title: 'Lighting',
+  titleIcon: 'lightbulb',
+  imageIcon: 'lightbulb',
+  isPlayable: true,
+  users: [],
+  // users: allUsers.slice(0, 1),
+  // users: Math.random()  > 0.5 ? randomUsers : [],
+  status: randomStatus,
+  priority: randomPriority,
+  imageUrl: Math.random() > 0.5 ? getRandomImage() : undefined,
 }
 
 export const Default: Story = {

--- a/src/EntityCard/EntityCard.stories.tsx
+++ b/src/EntityCard/EntityCard.stories.tsx
@@ -35,6 +35,7 @@ const randomPriority = priorities[Math.floor(Math.random() * priorities.length)]
 const initData: DataProps = {
   header: 'ep103sq002',
   path: 'ep103',
+  project: 'com',
   title: 'Lighting',
   titleIcon: 'lightbulb',
   imageIcon: 'lightbulb',
@@ -188,6 +189,7 @@ export const TaskStatus: Story = {
     header: undefined,
     path: undefined,
     isDraggable: false,
+    statusMiddle: true,
   },
   render: (args) => <Template {...args} />,
 }
@@ -200,6 +202,7 @@ export const ProgressView: Story = {
     priorityOptions: priorities,
     assigneeOptions: allUsers,
     statusOptions: statuses,
+    statusMiddle: true,
   },
   render: (args) => <StatusTemplate {...args} />,
 }

--- a/src/EntityCard/EntityCard.stories.tsx
+++ b/src/EntityCard/EntityCard.stories.tsx
@@ -158,9 +158,7 @@ const initData: DataProps = {
   titleIcon: 'lightbulb',
   imageIcon: 'lightbulb',
   isPlayable: true,
-  users: [],
-  // users: allUsers.slice(0, 1),
-  // users: Math.random()  > 0.5 ? randomUsers : [],
+  users: Math.random() > 0.5 ? randomUsers : [],
   status: randomStatus,
   priority: randomPriority,
   imageUrl: Math.random() > 0.5 ? getRandomImage() : undefined,
@@ -216,6 +214,19 @@ export const NoImage: Story = {
     ...initData,
     imageUrl:
       'http://localhost:3000/api/projects/demo_Commercial/tasks/807fb5901dab11ef95ad0242ac180005/thumbnail?updatedAt=2024-07-12T11:19:27.045329+00:00',
+  },
+  render: Template,
+}
+
+export const Version: Story = {
+  args: {
+    ...initData,
+    title: 'v001',
+    titleIcon: undefined,
+    header: 'animationChar1',
+    priority: undefined,
+    hidePriority: true,
+    users: [allUsers[0]],
   },
   render: Template,
 }

--- a/src/EntityCard/EntityCard.styled.ts
+++ b/src/EntityCard/EntityCard.styled.ts
@@ -403,6 +403,10 @@ export const Row = styled.div`
   justify-content: flex-start;
   &.full {
     justify-content: space-between;
+  }
+
+  &.full,
+  &.hide-priority {
     .tag.users {
       width: fit-content;
     }
@@ -595,7 +599,7 @@ export const Users = styled.div`
     &:after {
       content: '';
       position: absolute;
-      right: -3px;
+      right: -4px;
       bottom: 0;
       width: 24px;
       height: 24px;

--- a/src/EntityCard/EntityCard.styled.ts
+++ b/src/EntityCard/EntityCard.styled.ts
@@ -474,8 +474,19 @@ export const Tag = styled.span`
   /* user image overrides */
   &.users {
     padding: 0 1px;
-    background-color: unset;
-    width: 40px;
+    &:not(.empty) {
+      background-color: unset;
+    }
+    width: 34px;
+
+    .icon {
+      font-variation-settings: 'FILL' 1, 'wght' 200, 'GRAD' 200, 'opsz' 20;
+    }
+    &:not(.editable) {
+      .icon {
+        opacity: 0.5;
+      }
+    }
 
     .user-image {
       /* border-color: var(--md-sys-color-surface-container-high); */
@@ -561,6 +572,37 @@ export const StatusContainer = styled.div`
       span {
         overflow: hidden;
       }
+    }
+  }
+`
+
+export const Users = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  z-index: 10;
+  & > * + * {
+    margin-left: -18px;
+    background-color: var(--md-sys-color-surface-container);
+  }
+
+  /* add third user ring */
+  &.more {
+    left: -2px;
+    & > * + * {
+      margin-left: -20px;
+    }
+    &:after {
+      content: '';
+      position: absolute;
+      right: -3px;
+      bottom: 0;
+      width: 24px;
+      height: 24px;
+      border-radius: 100%;
+      background-color: var(--md-sys-color-surface-container-low);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      z-index: -3;
     }
   }
 `

--- a/src/EntityCard/EntityCard.styled.ts
+++ b/src/EntityCard/EntityCard.styled.ts
@@ -7,7 +7,7 @@ const showFullPath = css`
   /* show full path */
   grid-template-columns: 1fr;
   .path {
-    padding-right: 4px;
+    padding-right: 2px;
   }
 `
 
@@ -38,6 +38,7 @@ export const Card = styled.div<CardProps>`
   --active-color-active: var(--md-sys-color-primary-container-active);
   --active-color-text: var(--md-sys-color-on-primary-container);
   --active-border-color: var(--md-sys-color-primary);
+  --status-color: ${(props) => props.$statusColor};
 
   &.hover {
     --hover-transition: 0ms;
@@ -70,7 +71,7 @@ export const Card = styled.div<CardProps>`
   /* change bg color based on variant */
   &.status {
     /* change bg colour and box shadow color */
-    --default-color: ${(props) => props.$statusColor};
+    --default-color: var(--status-color);
 
     --default-color-lighter: ${(props) =>
       props.$statusColor ? adjustHexBrightness(props.$statusColor, 8) : undefined};
@@ -184,14 +185,6 @@ export const Card = styled.div<CardProps>`
 
   /* VARIANT */
   &.status {
-    .tag.status {
-      background-color: var(--active-color);
-      /* targets label and icon */
-      span {
-        color: var(--md-sys-color-inverse-on-surface) !important;
-      }
-    }
-
     /* hover but not active */
     &:not(.active):hover {
       .tag.status {
@@ -237,6 +230,19 @@ export const Card = styled.div<CardProps>`
         bottom: 0;
         min-height: calc(var(--size) + 4px);
         max-height: calc(var(--size) + 4px);
+        justify-content: flex-end;
+        padding-right: 2px;
+      }
+
+      .status-container {
+        padding-right: 0px;
+
+        &.middle {
+          .status-wrapper {
+            justify-content: center;
+            padding-right: 0px;
+          }
+        }
       }
 
       &:hover {
@@ -321,7 +327,7 @@ export const Header = styled.div`
   .expander {
     display: grid;
     grid-template-columns: 0fr;
-    transition: grid-template-columns 130ms;
+    transition: grid-template-columns 80ms ease;
     overflow: hidden;
 
     /* always show path */
@@ -331,12 +337,14 @@ export const Header = styled.div`
   }
 
   .path {
+    display: flex;
+    gap: 2px;
     min-width: 0;
     padding-right: 0px;
     transition: padding-right 130ms;
   }
 
-  span {
+  span:not(.slash) {
     word-break: break-all;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -391,7 +399,15 @@ export const Image = styled.img`
 export const Row = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+
+  justify-content: flex-start;
+  &.full {
+    justify-content: space-between;
+    .tag.users {
+      width: fit-content;
+    }
+  }
+
   z-index: 100;
   gap: 4px;
 
@@ -423,7 +439,7 @@ export const Tag = styled.span`
   align-items: center;
   justify-content: center;
   gap: 4px;
-  overflow: hidden;
+  /* overflow: hidden; */
   z-index: 10;
 
   &.title span:not(.icon) {
@@ -459,10 +475,17 @@ export const Tag = styled.span`
   &.users {
     padding: 0 1px;
     background-color: unset;
+    width: 40px;
 
     .user-image {
-      border-color: var(--md-sys-color-surface-container-high);
+      /* border-color: var(--md-sys-color-surface-container-high); */
       padding: 0px;
+
+      &.extra .initials {
+        font-size: 12px;
+        position: relative;
+        right: -5px;
+      }
     }
   }
 
@@ -494,7 +517,12 @@ export const StatusContainer = styled.div`
   max-height: calc(var(--size) + 4px);
 
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
+  padding-right: 2px;
+  &.middle {
+    padding-right: 0px;
+    justify-content: center;
+  }
   align-items: flex-end;
 
   /* the wrapper is the element that expands full width */
@@ -514,6 +542,13 @@ export const StatusContainer = styled.div`
 
   .status {
     gap: 0px;
+
+    background-color: var(--status-color);
+    /* targets label and icon */
+    span {
+      color: var(--md-sys-color-inverse-on-surface) !important;
+    }
+
     .status-label {
       white-space: nowrap;
     }

--- a/src/EntityCard/EntityCard.tsx
+++ b/src/EntityCard/EntityCard.tsx
@@ -43,13 +43,15 @@ type Section = 'title' | 'header' | 'users' | 'status' | 'priority'
 export interface EntityCardProps extends React.HTMLAttributes<HTMLDivElement> {
   header?: string // top header
   path?: string // top header
+  project?: string // top header
   showPath?: boolean // always show path
   title?: string // top left
   titleIcon?: IconType // top left
   isPlayable?: boolean // top right - play icon
   users?: User[] // bottom left
-  status?: Status // bottom center
-  priority?: PriorityType // bottom right
+  status?: Status // bottom right
+  statusMiddle?: boolean // puts status in the center and priority in the bottom right
+  priority?: PriorityType // bottom left after users
   imageUrl?: string
   imageAlt?: string
   imageIcon?: IconType
@@ -82,12 +84,14 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
     {
       header,
       path,
+      project,
       showPath,
       title = '',
       titleIcon,
       isPlayable,
       users,
       status,
+      statusMiddle,
       priority,
       imageUrl,
       imageAlt,
@@ -167,7 +171,6 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
     // check first and second user images
     const { users: userWithValidatedImages, isLoading: isUserImagesLoading } =
       useUserImagesLoader(users)
-    const statusBGColor = variant === 'status' && status?.color ? status.color : undefined
 
     const shouldShowTag = (value: any, name: Section) =>
       (!!value && !isLoading) || (isLoading && loadingSections.includes(name))
@@ -191,7 +194,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
           variant,
           props.className,
         )}
-        $statusColor={statusBGColor}
+        $statusColor={status?.color}
         tabIndex={0}
         onClick={(e) => {
           if (!clickedEditableElement(e)) {
@@ -212,7 +215,22 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
           <Styled.Header className={'header loading-visible'}>
             {path && (
               <div className={clsx('expander', { show: showPath })}>
-                <span className="path">... / {path} / </span>
+                <div className="path">
+                  {project && (
+                    <>
+                      <span>{project}</span>
+                      <span className="slash">/</span>
+                    </>
+                  )}
+                  {path && (
+                    <>
+                      <span>...</span>
+                      <span className="slash">/</span>
+                      <span>{path}</span>
+                      <span className="slash">/</span>
+                    </>
+                  )}
+                </div>
               </div>
             )}
             <span className="shot">{isLoading ? '' : header}</span>
@@ -245,7 +263,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             />
           )}
           {/* TOP ROW */}
-          <Styled.Row className="row row-top loading-visible">
+          <Styled.Row className="row row-top loading-visible full">
             {/* top left */}
             {(!isLoading || loadingSections.includes('title')) && (
               <Styled.Tag className={clsx('tag title', { isLoading })}>
@@ -268,7 +286,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             )}
           </Styled.Row>
           {/* BOTTOM ROW */}
-          <Styled.Row className="row row-bottom loading-visible">
+          <Styled.Row className={clsx('row row-bottom loading-visible', { full: statusMiddle })}>
             {atLeastOneEditable && (
               <>
                 {/* EDITORS */}
@@ -318,13 +336,15 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
                 onMouseEnter={(e) => handleEditableHover(e, 'assignees')}
                 onClick={(e) => handleEditableHover(e, 'assignees')}
               >
-                <UserImagesStacked users={userWithValidatedImages} size={26} gap={-0.5} max={2} />
+                <UserImagesStacked users={userWithValidatedImages} size={26} gap={-0.9} max={2} />
               </Styled.Tag>
             )}
 
             {/* bottom center - status */}
             {shouldShowTag(status, 'status') && (
-              <Styled.StatusContainer>
+              <Styled.StatusContainer
+                className={clsx('status-container', { middle: statusMiddle })}
+              >
                 <div className="status-wrapper">
                   <Styled.Tag
                     className={clsx('tag status', {

--- a/src/EntityCard/EntityCard.tsx
+++ b/src/EntityCard/EntityCard.tsx
@@ -8,6 +8,7 @@ import useUserImagesLoader from './useUserImagesLoader'
 import { Dropdown, DropdownRef } from '../Dropdowns/Dropdown'
 import { AssigneeSelect } from '../Dropdowns/AssigneeSelect'
 import { Status, StatusSelect } from '../Dropdowns/StatusSelect'
+import { UserImage } from '../User/UserImage'
 
 type NotificationType = 'comment' | 'due' | 'overdue'
 
@@ -89,7 +90,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
       title = '',
       titleIcon,
       isPlayable,
-      users,
+      users = [],
       status,
       statusMiddle,
       priority,
@@ -327,16 +328,32 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             )}
 
             {/* bottom left - users */}
-            {shouldShowTag(users, 'users') && (
+            {shouldShowTag(true, 'users') && (
               <Styled.Tag
                 className={clsx('tag users', {
                   isLoading: isUserImagesLoading || isLoading,
                   editable: assigneesEditable,
+                  empty: !users.length,
                 })}
                 onMouseEnter={(e) => handleEditableHover(e, 'assignees')}
                 onClick={(e) => handleEditableHover(e, 'assignees')}
               >
-                <UserImagesStacked users={userWithValidatedImages} size={26} gap={-0.9} max={2} />
+                {users.length ? (
+                  <Styled.Users className={clsx({ more: users.length > 2 })}>
+                    {[...userWithValidatedImages].slice(0, 2).map((user, i) => (
+                      <UserImage
+                        src={user.avatarUrl}
+                        key={i}
+                        name={user.name}
+                        style={{ zIndex: -i }}
+                        fullName={user.fullName || ''}
+                        size={26}
+                      />
+                    ))}
+                  </Styled.Users>
+                ) : (
+                  <Icon icon="person_add" />
+                )}
               </Styled.Tag>
             )}
 

--- a/src/EntityCard/EntityCard.tsx
+++ b/src/EntityCard/EntityCard.tsx
@@ -49,10 +49,11 @@ export interface EntityCardProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string // top left
   titleIcon?: IconType // top left
   isPlayable?: boolean // top right - play icon
-  users?: User[] // bottom left
+  users?: User[] | null // bottom left
   status?: Status // bottom right
   statusMiddle?: boolean // puts status in the center and priority in the bottom right
   priority?: PriorityType // bottom left after users
+  hidePriority?: boolean
   imageUrl?: string
   imageAlt?: string
   imageIcon?: IconType
@@ -94,6 +95,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
       status,
       statusMiddle,
       priority,
+      hidePriority,
       imageUrl,
       imageAlt,
       imageIcon,
@@ -220,12 +222,14 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
                   {project && (
                     <>
                       <span>{project}</span>
-                      <span className="slash">/</span>
+                      <span className="slash" style={{ marginRight: -2 }}>
+                        /
+                      </span>
                     </>
                   )}
                   {path && (
                     <>
-                      <span>...</span>
+                      <span>... </span>
                       <span className="slash">/</span>
                       <span>{path}</span>
                       <span className="slash">/</span>
@@ -287,7 +291,12 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             )}
           </Styled.Row>
           {/* BOTTOM ROW */}
-          <Styled.Row className={clsx('row row-bottom loading-visible', { full: statusMiddle })}>
+          <Styled.Row
+            className={clsx('row row-bottom loading-visible', {
+              full: statusMiddle,
+              ['hide-priority']: hidePriority,
+            })}
+          >
             {atLeastOneEditable && (
               <>
                 {/* EDITORS */}
@@ -333,12 +342,12 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
                 className={clsx('tag users', {
                   isLoading: isUserImagesLoading || isLoading,
                   editable: assigneesEditable,
-                  empty: !users.length,
+                  empty: !users?.length,
                 })}
                 onMouseEnter={(e) => handleEditableHover(e, 'assignees')}
                 onClick={(e) => handleEditableHover(e, 'assignees')}
               >
-                {users.length ? (
+                {users?.length ? (
                   <Styled.Users className={clsx({ more: users.length > 2 })}>
                     {[...userWithValidatedImages].slice(0, 2).map((user, i) => (
                       <UserImage
@@ -383,7 +392,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             )}
 
             {/* bottom right - priority */}
-            {shouldShowTag(priority, 'priority') && (
+            {shouldShowTag(priority && !hidePriority, 'priority') && (
               <Styled.Tag
                 className={clsx('tag', { editable: priorityEditable, isLoading })}
                 onMouseEnter={(e) => handleEditableHover(e, 'priority')}

--- a/src/EntityCard/EntityCard.tsx
+++ b/src/EntityCard/EntityCard.tsx
@@ -91,7 +91,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
       title = '',
       titleIcon,
       isPlayable,
-      users = [],
+      users,
       status,
       statusMiddle,
       priority,
@@ -337,7 +337,7 @@ export const EntityCard = forwardRef<HTMLDivElement, EntityCardProps>(
             )}
 
             {/* bottom left - users */}
-            {shouldShowTag(true, 'users') && (
+            {shouldShowTag(users, 'users') && (
               <Styled.Tag
                 className={clsx('tag users', {
                   isLoading: isUserImagesLoading || isLoading,

--- a/src/User/UserImage/UserImage.styled.ts
+++ b/src/User/UserImage/UserImage.styled.ts
@@ -12,8 +12,8 @@ export const CircleImage = styled.span`
   align-items: center;
 
   overflow: hidden;
-  background-color: var(--md-sys-color-surface-container-highest);
-  border: solid 1px var(--md-sys-color-outline);
+  background-color: var(--md-sys-color-surface-container-high);
+  border: solid 1px var(--md-sys-color-outline-variant);
   user-select: none;
   color: var(--md-sys-color-on-surface);
 

--- a/src/User/UserImage/UserImage.tsx
+++ b/src/User/UserImage/UserImage.tsx
@@ -23,7 +23,7 @@ export interface UserImageProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 export const UserImage = forwardRef<HTMLSpanElement, UserImageProps>(
-  ({ src, name, fullName, size = 30, highlight, className, ...props }, ref) => {
+  ({ src, name, fullName, size = 30, highlight, className, style, ...props }, ref) => {
     const fontSize = Math.round((13 / 30) * size)
     const nameData = fullName || name
 
@@ -31,12 +31,18 @@ export const UserImage = forwardRef<HTMLSpanElement, UserImageProps>(
 
     return (
       <Styled.CircleImage
-        style={{ width: size, maxHeight: size, minHeight: size, ...props.style }}
         ref={ref}
+        style={{ width: size, maxHeight: size, minHeight: size, ...style }}
         className={clsx(className, { initials: !src, highlight }, 'user-image')}
         {...props}
       >
-        {src ? <img src={src} /> : <span style={{ fontSize: `${fontSize}px` }}>{initials}</span>}
+        {src ? (
+          <img src={src} />
+        ) : (
+          <span style={{ fontSize: `${fontSize}px` }} className="initials">
+            {initials}
+          </span>
+        )}
       </Styled.CircleImage>
     )
   },

--- a/src/User/UserImagesStacked/UserImagesStacked.tsx
+++ b/src/User/UserImagesStacked/UserImagesStacked.tsx
@@ -32,16 +32,17 @@ export const UserImagesStacked = forwardRef<HTMLDivElement, UserImagesStackedPro
     // limit to 5 users
     const usersToShow = [...users].slice(0, max)
 
+    const extraCount = length - max + 1 // +1 for the user we just removed
+
     // show extras
     if (length > max) {
       // remove last user
       usersToShow.pop()
       // add a +1 user
-      const extraCount = length - max + 1 // +1 for the user we just removed
       const extraString = extraCount > 9 ? '++' : '+ ' + extraCount
       usersToShow.push({
         fullName: extraString,
-        name: extraString,
+        name: 'extra',
       })
     }
 
@@ -56,6 +57,7 @@ export const UserImagesStacked = forwardRef<HTMLDivElement, UserImagesStackedPro
             style={{ zIndex: -i, width: size, height: size, ...userStyle }}
             highlight={self}
             size={size}
+            className={name}
           />
         ))}
       </StackedStyled>

--- a/src/User/UserImagesStacked/UserImagesStacked.tsx
+++ b/src/User/UserImagesStacked/UserImagesStacked.tsx
@@ -13,7 +13,7 @@ const StackedStyled = styled.div<{ $gap: number }>`
 
 export interface User {
   avatarUrl?: string
-  fullName?: string
+  fullName?: string | null
   name: string
   self?: boolean
 }


### PR DESCRIPTION
## Changes

- New prop: `hidePriority` to explicitly hide the priority and make users width dynamic.
- New prop: `project` shown alongside `path` when hovering.
- New prop: `statusMiddle` now by default status is positioned bottom right but can be positioned to the middle.
- Default layout has changed with status bottom right and priority right of users.
- Using custom styling for stacked users to make it more condensed.
- When `users` props is empty list `[]` show an icon to add assignees. `users=undefined | null` will hide tag completely.
- Invert status tag colour to have status colour as the background.

![image](https://github.com/user-attachments/assets/aea35b05-d733-4d35-8102-21216051226e)


