### PR TITLE
FileUpload - extra headers options to allow for custom elements in header bar

### DIFF
--- a/src/FileUpload/FileUpload.tsx
+++ b/src/FileUpload/FileUpload.tsx
@@ -34,6 +34,7 @@ export interface FileUploadProps extends FormProps {
   confirmLabel?: string
   saveButton?: React.ReactNode
   header?: React.ReactNode
+  extraHeaderActions?: React.ReactNode
   footer?: React.ReactNode
   onSubmit?: (files: CustomFile[]) => void
   isFetching?: boolean
@@ -65,6 +66,7 @@ export const FileUpload = forwardRef<HTMLFormElement, FileUploadProps>(
       confirmLabel,
       saveButton,
       header,
+      extraHeaderActions,
       footer,
       onSubmit,
       isFetching,
@@ -473,11 +475,13 @@ export const FileUpload = forwardRef<HTMLFormElement, FileUploadProps>(
             header || 'Uploaded ' + fileOrFiles
           ) : (
             <>
-              {title ? (
-                <h3>{title}</h3>
-              ) : (
-                <h3>{fileOrFiles.charAt(0).toUpperCase() + fileOrFiles.slice(1)} Uploader</h3>
-              )}
+              {!extraHeaderActions &&
+                (title ? (
+                  <h3>{title}</h3>
+                ) : (
+                  <h3>{fileOrFiles.charAt(0).toUpperCase() + fileOrFiles.slice(1)} Uploader</h3>
+                ))}
+              {extraHeaderActions && extraHeaderActions}
               <Spacer />
               <Button
                 icon="delete"


### PR DESCRIPTION
Allowing for custom components injection in the FileUpload component instead of the title.

They would show up on the left side of the actions header, i.e. the "Manage uploads" button in the screenshot below:
![image](https://github.com/user-attachments/assets/4c23fe81-34f5-410a-9e11-c3c090876e80)
