### PR TITLE
feat: add `pt` props to support partial customization for Dropdown an…

### DIFF
--- a/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
+++ b/src/Dropdowns/Dropdown/DefaultValueTemplate.tsx
@@ -106,7 +106,9 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
       style={style}
       className={clsx('template-value', className, { error: hasError, open: isOpen })}
     >
-      {noValue ? (
+      {childrenCustom ? (
+        childrenCustom
+      ) : noValue ? (
         <>
           <ContentStyled>
             <ValueStyled style={{ opacity: 0.5 }} className="placeholder">
@@ -164,7 +166,6 @@ export const DefaultValueTemplate: FC<DefaultValueTemplateProps> = ({
           )}
         </>
       )}
-      {childrenCustom}
 
       <Icon icon={dropIcon} className="control" />
     </DefaultValueStyled>

--- a/src/Dropdowns/Dropdown/Dropdown.tsx
+++ b/src/Dropdowns/Dropdown/Dropdown.tsx
@@ -108,6 +108,11 @@ export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   buttonProps?: Styled.ButtonType['defaultProps']
   activateKeys?: string[]
   startContent?: (value: string[], selected: string[], isOpen: boolean) => React.ReactNode
+  pt?: {
+    button?: Partial<React.HTMLAttributes<HTMLButtonElement>>
+    list?: Partial<React.HTMLAttributes<HTMLDivElement>>
+    container?: Partial<React.HTMLAttributes<HTMLDivElement>>
+  }
 }
 
 export interface DropdownRef {
@@ -183,6 +188,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
       buttonProps,
       activateKeys = ['Enter', 'Space', 'NumpadEnter', 'Tab'],
       startContent,
+      pt,
       ...props
     },
     ref,
@@ -883,8 +889,9 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
           $isChanged={!!isChanged}
           $isOpen={isOpen}
           {...buttonProps}
-          style={buttonStyle}
-          className={`button ${buttonClassName}`}
+          {...pt?.button}
+          style={{ ...buttonStyle, ...pt?.button?.style }}
+          className={clsx('button', buttonClassName, pt?.button?.className)}
         >
           {valueTemplateNode && valueTemplateNode(value || [], selected || [], isOpen) ? (
             valueTemplateNode(value || [], selected || [], isOpen)
@@ -898,6 +905,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
         {isOpen &&
           createPortal(
             <Styled.Container
+              {...pt?.container}
               style={{
                 opacity: isShowOptions ? 1 : 0,
                 left: pos?.left || 'unset',
@@ -906,6 +914,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
                 translate: offScreen ? '0 -100%' : 'none',
                 transformOrigin: offScreen ? 'center bottom' : 'center top',
                 ...itemStyle,
+                ...pt?.container?.style,
               }}
               $message={message || ''}
               $messageOverButton={messageOverButton}
@@ -914,7 +923,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
               $hidden={!isShowOptions}
               onSubmit={handleSearchSubmit}
               ref={formRef}
-              className={'container'}
+              className={clsx('container', pt?.container?.className)}
             >
               {startContent && (
                 <Styled.StartContent>
@@ -943,8 +952,9 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(
                 defer
               >
                 <Styled.Options
-                  style={{ minWidth, maxWidth: widthExpandMax ? minWidth : 'unset', ...listStyle }}
-                  className={clsx('options', { usingKeyboard })}
+                  {...pt?.list}
+                  style={{ minWidth, maxWidth: widthExpandMax ? minWidth : 'unset', ...listStyle, ...pt?.list?.style }}
+                  className={clsx('options', { usingKeyboard }, pt?.list?.className)}
                   ref={optionsRef}
                 >
                   {[...missingOptions, ...showOptions].map((option, i) => (

--- a/src/Dropdowns/SortingDropdown/SortCard.styled.ts
+++ b/src/Dropdowns/SortingDropdown/SortCard.styled.ts
@@ -13,6 +13,7 @@ export const Card = styled.div<{ $disabled: boolean }>`
   justify-content: center;
   align-items: center;
   min-height: unset;
+  min-width: fit-content;
   gap: 4px;
   overflow: hidden;
 

--- a/src/Dropdowns/SortingDropdown/SortingDropdown.tsx
+++ b/src/Dropdowns/SortingDropdown/SortingDropdown.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react'
+import { FC, HTMLAttributes } from 'react'
 import { DefaultValueTemplate, Dropdown, DropdownProps } from '../Dropdown'
 import styled from 'styled-components'
+import clsx from 'clsx'
 import SortCard from './SortCard'
 
 const StyledDropdown = styled(Dropdown)`
@@ -26,6 +27,9 @@ export interface SortingDropdownProps extends Omit<DropdownProps, 'value' | 'onC
   options: SortCardType[]
   onChange: (value: SortCardType[]) => void
   title: string
+  pt?: {
+    chip?: Partial<HTMLAttributes<HTMLDivElement>>
+  }
 }
 
 export const SortingDropdown: FC<SortingDropdownProps> = ({
@@ -34,6 +38,7 @@ export const SortingDropdown: FC<SortingDropdownProps> = ({
   onChange,
   title = 'Sort by',
   multiSelect = true,
+  pt,
   ...props
 }) => {
   const handleChange = (v: DropdownProps['value']) => {
@@ -108,6 +113,8 @@ export const SortingDropdown: FC<SortingDropdownProps> = ({
                     <SortCard
                       key={id}
                       {...sortValue}
+                      {...pt?.chip}
+                      className={clsx(pt?.chip?.className)}
                       id={sortValue.id}
                       label={sortValue.label}
                       sortOrder={sortValue?.sortOrder ?? true}


### PR DESCRIPTION


## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

 Add pt (passthrough) prop support to Dropdown and SortingDropdown components, following the existing pattern used in EntityCard and Dialog.

  - Dropdown: Add pt prop with keys button, list, and container to pass HTML attributes (style, className, etc.) to inner elements
  - SortingDropdown: Add pt prop with key chip to pass HTML attributes to SortCard elements
  - DefaultValueTemplate: When childrenCustom is provided, skip rendering the empty ContentStyled container (which has flex: 1) so custom content gets full available space
  - SortCard: Add min-width: fit-content to prevent chip label from being truncated

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

 The pt pattern follows the same convention as EntityCard:
  - Each key maps to an inner element
  - Value is Partial<HTMLAttributes<...>>
  - Props are spread with {...pt?.key}
  - className is merged via clsx(existingClasses, pt?.key?.className)
  - style is merged via { ...existingStyle, ...pt?.key?.style }

### Additional context

<!-- Add any other context or screenshots here. -->

Before 
<img width="147" height="48" alt="Screenshot 2026-03-25 at 13 58 29" src="https://github.com/user-attachments/assets/d5d3337c-f271-4ec1-ad1d-1b66410a94a7" />

After:
<img width="213" height="54" alt="Screenshot 2026-03-25 at 14 23 05" src="https://github.com/user-attachments/assets/b13f0103-0019-460a-a052-c9aa3743c9e5" />





Needed by ayon-frontend ([#1868](https://github.com/ynput/ayon-frontend/issues/1868))