### PR TITLE
Search filter: prevent long filters overflowing the toolbar

### DIFF
--- a/src/SearchFilter/SearchFilter.styled.ts
+++ b/src/SearchFilter/SearchFilter.styled.ts
@@ -5,6 +5,11 @@ export const Container = styled.div`
   position: relative;
   width: 100%;
 
+  /* allow the whole bar to shrink inside a flex toolbar instead of forcing its
+     content width onto siblings (which would push toolbar actions off screen).
+     the excess chips then scroll inside .filter-values / .search-bar. */
+  min-width: 0;
+
   /* compact mode: shrink the bar to 28px with smaller padding/text.
      scoped to .search-bar so the dropdown keeps its default sizing. */
   &.compact {

--- a/src/SearchFilter/SearchFilterItem/SearchFilterItem.styled.ts
+++ b/src/SearchFilter/SearchFilterItem/SearchFilterItem.styled.ts
@@ -13,6 +13,13 @@ export const FilterItem = styled.div`
   /* padding-right: 8px; */
   border-radius: 4px;
 
+  /* keep the check/remove buttons and the field label at full size — only the
+     value chip is allowed to shrink and ellipsis */
+  > .button,
+  > .label {
+    flex-shrink: 0;
+  }
+
   cursor: pointer;
   &:hover {
     background-color: var(--md-sys-color-surface-container-high-hover);

--- a/src/SearchFilter/SearchFilterItemValue.tsx
+++ b/src/SearchFilter/SearchFilterItemValue.tsx
@@ -31,6 +31,7 @@ const ValueChip = styled.div`
      replaced by an input, which is free to grow into the available bar space. */
   .label {
     max-width: 260px;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/SearchFilter/SearchFilterItemValue.tsx
+++ b/src/SearchFilter/SearchFilterItemValue.tsx
@@ -12,10 +12,28 @@ const ValueChip = styled.div`
   gap: var(--base-gap-small);
   border-radius: var(--border-radius-m);
 
+  /* allow the chip to shrink below its content so the label can ellipsis */
+  min-width: 0;
+
+  .icon {
+    flex-shrink: 0;
+  }
+
   img {
     width: 16px;
     height: 16px;
     border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  /* cap a long value (e.g. a big custom search) at a readable width, then
+     ellipsis. this only affects the static display — while editing the value is
+     replaced by an input, which is free to grow into the available bar space. */
+  .label {
+    max-width: 260px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* hide label */


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Long search filters no longer push the toolbar actions off screen, and a single long filter truncates instead of dominating the bar.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

- `min-width: 0` on the SearchFilter `Container` so the bar can shrink in a flex toolbar; excess chips scroll inside `.filter-values` instead of pushing siblings off screen.
- Cap the value `.label` at 260px with ellipsis (`SearchFilterItemValue`); the inline edit input is a separate element, so it still grows freely.
- `flex-shrink: 0` on chip buttons, field label, icons and avatars so only the value text truncates.

### Additional context

<!-- Add any other context or screenshots here. -->

https://github.com/user-attachments/assets/6b8cc2a4-c7b2-4e48-a788-93943b9686c4


Closes #228
Connected: ynput/ayon-frontend#2157
